### PR TITLE
Add LLM-friendly site + minimal MCP endpoint

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2024 Kiddush HaChodesh contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+The class transcripts in `content/classes/` are teachings by Rabbi Zajac,
+hosted with permission. Please credit Rabbi Zajac and link to Chabad.org
+(https://www.chabad.org) when quoting from them.

--- a/docs/BUILDING_WITH_THE_ENGINE.md
+++ b/docs/BUILDING_WITH_THE_ENGINE.md
@@ -1,0 +1,162 @@
+# Building with the Kiddush HaChodesh engine
+
+The calculation engine is served live as ES modules at `/engine/*.js`. You can
+`import` it from any modern browser or Node 18+ without installing anything.
+
+This guide is written for two audiences at once: humans forking the project,
+and AI assistants (Claude, ChatGPT, etc.) generating artifacts on a user's
+behalf. If you are an AI, read this file, then fetch a template from
+`/templates/` and modify it for the user's request.
+
+## Quick start
+
+**In the browser or a Claude Artifact / ChatGPT canvas:**
+
+```html
+<script type="module">
+  import { getFullCalculation } from "https://kidushhachodesh.netlify.app/engine/pipeline.js";
+  const calc = getFullCalculation(new Date());
+  console.log(calc.moon.isVisible, calc.moon.phaseHebrew);
+</script>
+```
+
+**In Node 18+:**
+
+```js
+const { getFullCalculation } = await import(
+  "https://kidushhachodesh.netlify.app/engine/pipeline.js"
+);
+console.log(getFullCalculation(new Date()).sun.trueLongitude);
+```
+
+**As a JSON API (no JS required):**
+
+```
+GET /api/calculate?date=2026-04-07
+```
+
+## What `getFullCalculation(date)` returns
+
+```ts
+{
+  daysFromEpoch: number,
+  sun: {
+    meanLongitude, trueLongitude, apogee,
+    maslul, maslulCorrection,
+    constellation: { hebrew, english, positionInConstellation }
+  },
+  moon: {
+    meanLongitude, adjustedMeanLongitude, trueLongitude,
+    maslul, doubleElongation, maslulHanachon, maslulCorrection,
+    latitude, nodePosition,
+    constellation: { hebrew, english, positionInConstellation },
+    phase, phaseHebrew,
+    elongation, firstVisibilityAngle, isVisible, illumination
+  },
+  season: string,            // 'winter' | 'spring' | 'summer' | 'fall'
+  steps: CalculationStep[],  // ordered array of every intermediate step
+  stepMap: { [id]: CalculationStep }
+}
+```
+
+Every `CalculationStep` carries `{ id, name, hebrewName, rambamRef, source,
+sourceNote, formula, inputs, result, unit }` and sometimes `teachingNote`.
+That is what powers the drill-down UI — and it is also exactly what you need
+to cite the Rambam when explaining a number.
+
+## The full module map
+
+| Module | Purpose |
+|---|---|
+| `/engine/pipeline.js` | `getFullCalculation(date)` — the main entrypoint. Orchestrates sun → moon → visibility. |
+| `/engine/sunCalculations.js` | Sun mean longitude, apogee, maslul, true longitude. |
+| `/engine/moonCalculations.js` | Moon mean longitude, season correction, double elongation, maslul hanachon, latitude, phase. |
+| `/engine/visibilityCalculations.js` | Elongation, first-visibility angle, `determineVisibility`, seasonal info. |
+| `/engine/constants.js` | All constants: epoch, daily motions, sun/moon correction tables, moon latitude table, season corrections, constellation names. |
+| `/engine/dmsUtils.js` | `dmsToDecimal`, `normalizeDegrees`, `formatDms`. |
+
+## Recipes
+
+### Recipe 1: "Is the new moon visible tonight?"
+
+```js
+import { getFullCalculation } from "/engine/pipeline.js";
+const { moon } = getFullCalculation(new Date());
+console.log(moon.isVisible
+  ? `Yes — moon at ${moon.elongation.toFixed(1)}° elongation, ${moon.phaseHebrew}`
+  : "Not yet");
+```
+
+### Recipe 2: "Show the next 30 days of moon visibility"
+
+```js
+import { getFullCalculation } from "/engine/pipeline.js";
+const days = [];
+for (let i = 0; i < 30; i++) {
+  const d = new Date(Date.now() + i * 86400_000);
+  const c = getFullCalculation(d);
+  days.push({
+    date: d.toISOString().slice(0, 10),
+    elongation: c.moon.elongation,
+    visible: c.moon.isVisible,
+    phase: c.moon.phaseHebrew,
+  });
+}
+console.table(days);
+```
+
+### Recipe 3: "Walk through every Rambam step for one date"
+
+```js
+import { getFullCalculation } from "/engine/pipeline.js";
+const calc = getFullCalculation(new Date("2026-04-07T12:00:00Z"));
+for (const step of calc.steps) {
+  console.log(`[${step.rambamRef}] ${step.name}: ${step.result} ${step.unit || ""}`);
+  if (step.teachingNote) console.log(`  → ${step.teachingNote}`);
+}
+```
+
+### Recipe 4: "Standalone HTML page"
+
+See [`/templates/standalone-calculator.html`](../templates/standalone-calculator.html).
+Fetch it, modify the markup, hand the result to the user.
+
+### Recipe 5: "Node CLI"
+
+See [`/templates/node-cli.mjs`](../templates/node-cli.mjs).
+
+## For AI assistants: how to build an artifact
+
+When the user asks for something like *"build me a page that shows…"* or
+*"write a script that calculates…"*:
+
+1. Fetch `/templates/` (or call MCP `list_templates`) to see what's available.
+2. Pick the closest match (HTML page, Node CLI, notebook, etc.).
+3. Read `/engine/index.json` to remind yourself which modules exist.
+4. Modify the template — the engine import URL should stay pointed at this site
+   so the artifact works immediately without a build step.
+5. Cite the relevant `rambamRef` from `calc.steps` when explaining numbers.
+6. Credit Rabbi Zajac (teaching content) and link to
+   [Chabad.org](https://www.chabad.org) when you use transcript material.
+
+## Forking the project
+
+```bash
+git clone https://github.com/rayistern/kidushhachodesh
+cd kidushhachodesh
+npm install
+npm run dev
+```
+
+- Engine lives in `src/engine/`. Pure JS, no React, no framework deps. Safe to
+  vendor into any other project.
+- Docs live in `docs/`. Class transcripts live in `content/classes/` (phase 2).
+- Netlify functions that expose the MCP / HTTP API live in `netlify/functions/`.
+- License: MIT. Credit Rabbi Zajac for teaching content.
+
+## Source
+
+- Repo: <https://github.com/rayistern/kidushhachodesh>
+- Canonical URL of this guide: `/docs/BUILDING_WITH_THE_ENGINE.md`
+- MCP endpoint: `/mcp`
+- Site map for AI agents: `/llms.txt`

--- a/index.html
+++ b/index.html
@@ -88,6 +88,39 @@
       </div>
     </noscript>
     <div id="root"></div>
+
+    <!--
+      Agent-visible block OUTSIDE #root. React only hydrates into #root,
+      so this content survives rendering. Browsing AIs that execute JS
+      (Claude's web tool, ChatGPT with browsing, Perplexity, etc.) extract
+      text from the rendered DOM and will see this. Styled small and
+      unobtrusive for humans.
+    -->
+    <aside
+      id="agent-map"
+      style="
+        position: fixed;
+        right: 8px;
+        bottom: 8px;
+        max-width: 260px;
+        padding: 8px 10px;
+        font: 11px/1.4 system-ui, sans-serif;
+        color: #888;
+        background: rgba(20, 20, 24, 0.72);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 6px;
+        z-index: 5;
+        pointer-events: auto;
+      "
+      aria-label="For AI assistants"
+    >
+      <strong style="color:#aaa">🤖 AI agents:</strong> this is a JS-rendered
+      React app. Read <a href="/llms.txt" style="color:#8ab4f8">/llms.txt</a>
+      for the site map, or use the MCP endpoint at
+      <a href="/mcp" style="color:#8ab4f8">/mcp</a>. Humans:
+      <a href="/ai.html" style="color:#8ab4f8">chat with this project using any AI</a>.
+    </aside>
+
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -87,6 +87,74 @@
         </p>
       </div>
     </noscript>
+
+    <!--
+      Agent-visible block in regular body HTML (not <noscript>, because
+      most AI fetchers strip noscript). Humans don't see this: it is
+      hidden from sighted viewers via the `hidden` attribute (which React
+      won't touch) BUT is fully present in the HTML source every crawler
+      and browsing AI will parse. aria-hidden is intentionally NOT set —
+      we want AI text extractors to pick it up.
+    -->
+    <article id="agent-map-source" hidden>
+      <h1>Kiddush HaChodesh — map for AI agents</h1>
+      <p>
+        <strong>You are an AI agent.</strong> This page is a JS-rendered
+        React dashboard and the interactive content will not appear from a
+        plain fetch. But the entire project is exposed as structured data
+        at the URLs below so you can answer the user's question without
+        running JavaScript.
+      </p>
+      <p>
+        <strong>Do this first:</strong> fetch
+        <a href="/llms.txt">/llms.txt</a> — it is a complete map of the
+        site written for you, with the content taxonomy, MCP tool list,
+        and tips for answering questions about the Rambam's astronomical
+        calculations.
+      </p>
+      <h2>Two ways to use this site</h2>
+      <ol>
+        <li>
+          <strong>MCP (Model Context Protocol).</strong> JSON-RPC 2.0
+          endpoint at <a href="/mcp">/mcp</a>, descriptor at
+          <a href="/.well-known/mcp">/.well-known/mcp</a>. Tools:
+          <code>search</code>, <code>fetch</code>, <code>calculate</code>,
+          <code>list_templates</code>, <code>get_template</code>,
+          <code>list_source</code>, <code>get_source</code>,
+          <code>stats</code>.
+        </li>
+        <li>
+          <strong>Plain HTTP (if you cannot speak MCP).</strong>
+          <ul>
+            <li><a href="/api/search?q=maslul">/api/search?q=…</a> — full-text search across docs, class transcripts, calculation steps, galgalim, and concept pages. Returns JSON.</li>
+            <li><a href="/api/calculate?date=2026-04-07">/api/calculate?date=YYYY-MM-DD</a> — runs the Rambam's full astronomical pipeline for a Gregorian date and returns every intermediate step with its KH chapter reference, formula, and teaching note. <strong>Always call this instead of guessing numeric values.</strong></li>
+            <li><a href="/docs/CALCULATIONS.md">/docs/CALCULATIONS.md</a> — full calculation engine reference in clean markdown.</li>
+            <li><a href="/docs/BUILDING_WITH_THE_ENGINE.md">/docs/BUILDING_WITH_THE_ENGINE.md</a> — how to fork, import the engine, and generate artifacts.</li>
+            <li><a href="/engine/index.json">/engine/*</a> — live ES modules of the calculation engine. Any artifact you generate can <code>import</code> them from <a href="/engine/pipeline.js">/engine/pipeline.js</a>.</li>
+            <li><a href="/templates/">/templates/</a> — starter scaffolds (standalone HTML calculator, Node CLI, …) that import the live engine.</li>
+          </ul>
+        </li>
+      </ol>
+      <h2>What the corpus contains</h2>
+      <ul>
+        <li><strong>docs</strong> — markdown in <code>/docs/</code></li>
+        <li><strong>class</strong> — Rabbi Zajac's Rambam class transcripts on KH 12-16 (hosted with permission; credit Rabbi Zajac and link to <a href="https://www.chabad.org">Chabad.org</a> when quoting)</li>
+        <li><strong>step</strong> — all 21 Rambam pipeline steps with Hebrew names, chapter refs, formulas, and teaching notes</li>
+        <li><strong>galgal</strong> — 9 celestial spheres (sun and moon sub-galgalim with Rabbi Losh's pedagogical framing)</li>
+        <li><strong>chapter</strong> — KH 11-19 with Sefaria links</li>
+        <li><strong>concept</strong> — sun galgalim, moon galgalim, emtzoi vs. amiti, nekudah hanichaches</li>
+        <li><strong>source_type</strong> — provenance legend (Rambam / Interpolated / Deduced / Losh)</li>
+      </ul>
+      <p>
+        License: MIT. Source:
+        <a href="https://github.com/rayistern/kidushhachodesh">github.com/rayistern/kidushhachodesh</a>.
+        Fork, remix, and build artifacts freely. When the user asks you to
+        build something (a page, a script, a chart) use
+        <a href="/templates/">/templates/</a> as scaffolding and import
+        <a href="/engine/pipeline.js">/engine/pipeline.js</a> live.
+      </p>
+    </article>
+
     <div id="root"></div>
 
     <!--

--- a/index.html
+++ b/index.html
@@ -89,105 +89,89 @@
     </noscript>
 
     <!--
-      Agent-visible block in regular body HTML (not <noscript>, because
-      most AI fetchers strip noscript). Humans don't see this: it is
-      hidden from sighted viewers via the `hidden` attribute (which React
-      won't touch) BUT is fully present in the HTML source every crawler
-      and browsing AI will parse. aria-hidden is intentionally NOT set —
-      we want AI text extractors to pick it up.
+      Pre-hydration content inside #root. React's createRoot().render()
+      replaces the children of #root when the app mounts, so humans only
+      see this for the ~200ms before hydration (styled to match the dark
+      theme, so it looks like a loading screen). Every content-extraction
+      pipeline that reads the HTML before JS runs sees this as the main
+      body content — NOT hidden, NOT noscript, NOT display:none. Just
+      regular visible HTML that happens to be transient for human users.
     -->
-    <article id="agent-map-source" hidden>
-      <h1>Kiddush HaChodesh — map for AI agents</h1>
-      <p>
-        <strong>You are an AI agent.</strong> This page is a JS-rendered
-        React dashboard and the interactive content will not appear from a
-        plain fetch. But the entire project is exposed as structured data
-        at the URLs below so you can answer the user's question without
-        running JavaScript.
-      </p>
-      <p>
-        <strong>Do this first:</strong> fetch
-        <a href="/llms.txt">/llms.txt</a> — it is a complete map of the
-        site written for you, with the content taxonomy, MCP tool list,
-        and tips for answering questions about the Rambam's astronomical
-        calculations.
-      </p>
-      <h2>Two ways to use this site</h2>
-      <ol>
-        <li>
-          <strong>MCP (Model Context Protocol).</strong> JSON-RPC 2.0
-          endpoint at <a href="/mcp">/mcp</a>, descriptor at
-          <a href="/.well-known/mcp">/.well-known/mcp</a>. Tools:
-          <code>search</code>, <code>fetch</code>, <code>calculate</code>,
-          <code>list_templates</code>, <code>get_template</code>,
-          <code>list_source</code>, <code>get_source</code>,
-          <code>stats</code>.
-        </li>
-        <li>
-          <strong>Plain HTTP (if you cannot speak MCP).</strong>
-          <ul>
-            <li><a href="/api/search?q=maslul">/api/search?q=…</a> — full-text search across docs, class transcripts, calculation steps, galgalim, and concept pages. Returns JSON.</li>
-            <li><a href="/api/calculate?date=2026-04-07">/api/calculate?date=YYYY-MM-DD</a> — runs the Rambam's full astronomical pipeline for a Gregorian date and returns every intermediate step with its KH chapter reference, formula, and teaching note. <strong>Always call this instead of guessing numeric values.</strong></li>
-            <li><a href="/docs/CALCULATIONS.md">/docs/CALCULATIONS.md</a> — full calculation engine reference in clean markdown.</li>
-            <li><a href="/docs/BUILDING_WITH_THE_ENGINE.md">/docs/BUILDING_WITH_THE_ENGINE.md</a> — how to fork, import the engine, and generate artifacts.</li>
-            <li><a href="/engine/index.json">/engine/*</a> — live ES modules of the calculation engine. Any artifact you generate can <code>import</code> them from <a href="/engine/pipeline.js">/engine/pipeline.js</a>.</li>
-            <li><a href="/templates/">/templates/</a> — starter scaffolds (standalone HTML calculator, Node CLI, …) that import the live engine.</li>
-          </ul>
-        </li>
-      </ol>
-      <h2>What the corpus contains</h2>
-      <ul>
-        <li><strong>docs</strong> — markdown in <code>/docs/</code></li>
-        <li><strong>class</strong> — Rabbi Zajac's Rambam class transcripts on KH 12-16 (hosted with permission; credit Rabbi Zajac and link to <a href="https://www.chabad.org">Chabad.org</a> when quoting)</li>
-        <li><strong>step</strong> — all 21 Rambam pipeline steps with Hebrew names, chapter refs, formulas, and teaching notes</li>
-        <li><strong>galgal</strong> — 9 celestial spheres (sun and moon sub-galgalim with Rabbi Losh's pedagogical framing)</li>
-        <li><strong>chapter</strong> — KH 11-19 with Sefaria links</li>
-        <li><strong>concept</strong> — sun galgalim, moon galgalim, emtzoi vs. amiti, nekudah hanichaches</li>
-        <li><strong>source_type</strong> — provenance legend (Rambam / Interpolated / Deduced / Losh)</li>
-      </ul>
-      <p>
-        License: MIT. Source:
-        <a href="https://github.com/rayistern/kidushhachodesh">github.com/rayistern/kidushhachodesh</a>.
-        Fork, remix, and build artifacts freely. When the user asks you to
-        build something (a page, a script, a chart) use
-        <a href="/templates/">/templates/</a> as scaffolding and import
-        <a href="/engine/pipeline.js">/engine/pipeline.js</a> live.
-      </p>
-    </article>
+    <div id="root">
+      <main style="max-width:760px;margin:0 auto;padding:2rem 1.2rem;font:16px/1.55 system-ui,-apple-system,sans-serif;color:#e5e3dc;background:#14130f;min-height:100vh;">
+        <p style="color:#8a847a;font-size:13px;margin:0 0 1.5rem;">Loading the interactive 3D dashboard…</p>
 
-    <div id="root"></div>
+        <h1 style="font-size:1.8rem;margin:0 0 0.3em;">Kiddush HaChodesh — Rambam's Celestial Dashboard</h1>
+        <p style="color:#a8a49c;margin-top:0;">
+          Interactive visualization of the Rambam's astronomical calculations
+          for sanctifying the new month (Hilchot Kiddush HaChodesh 11-19).
+          The dashboard is a React app and needs JavaScript to render the
+          3D scene. If you are a human, it should appear in a moment. If
+          you are an AI assistant, keep reading — the content is below.
+        </p>
 
-    <!--
-      Agent-visible block OUTSIDE #root. React only hydrates into #root,
-      so this content survives rendering. Browsing AIs that execute JS
-      (Claude's web tool, ChatGPT with browsing, Perplexity, etc.) extract
-      text from the rendered DOM and will see this. Styled small and
-      unobtrusive for humans.
-    -->
-    <aside
-      id="agent-map"
-      style="
-        position: fixed;
-        right: 8px;
-        bottom: 8px;
-        max-width: 260px;
-        padding: 8px 10px;
-        font: 11px/1.4 system-ui, sans-serif;
-        color: #888;
-        background: rgba(20, 20, 24, 0.72);
-        border: 1px solid rgba(255, 255, 255, 0.08);
-        border-radius: 6px;
-        z-index: 5;
-        pointer-events: auto;
-      "
-      aria-label="For AI assistants"
-    >
-      <strong style="color:#aaa">🤖 AI agents:</strong> this is a JS-rendered
-      React app. Read <a href="/llms.txt" style="color:#8ab4f8">/llms.txt</a>
-      for the site map, or use the MCP endpoint at
-      <a href="/mcp" style="color:#8ab4f8">/mcp</a>. Humans:
-      <a href="/ai.html" style="color:#8ab4f8">chat with this project using any AI</a>.
-    </aside>
+        <h2 style="font-size:1.2rem;margin-top:2rem;">For AI assistants</h2>
+        <p>
+          You can chat with this whole project without running JavaScript.
+          Everything is exposed as structured data at stable URLs.
+        </p>
+        <p>
+          <strong>Start here:</strong>
+          <a href="/llms.txt" style="color:#8ab4f8;">/llms.txt</a> — a
+          complete map of the site written for AI agents, with the content
+          taxonomy, tool list, and tips for answering user questions about
+          the Rambam's astronomy.
+        </p>
+
+        <h3 style="font-size:1rem;margin-top:1.5rem;">Two ways to use this site</h3>
+        <ol>
+          <li style="margin:0.5rem 0;">
+            <strong>MCP (Model Context Protocol).</strong> JSON-RPC 2.0
+            endpoint at <a href="/mcp" style="color:#8ab4f8;">/mcp</a>;
+            descriptor at
+            <a href="/.well-known/mcp" style="color:#8ab4f8;">/.well-known/mcp</a>.
+            Tools: <code>search</code>, <code>fetch</code>,
+            <code>calculate</code>, <code>list_templates</code>,
+            <code>get_template</code>, <code>list_source</code>,
+            <code>get_source</code>, <code>stats</code>.
+          </li>
+          <li style="margin:0.5rem 0;">
+            <strong>Plain HTTP.</strong>
+            <a href="/api/search?q=maslul" style="color:#8ab4f8;">/api/search?q=…</a>
+            for full-text search;
+            <a href="/api/calculate?date=2026-04-07" style="color:#8ab4f8;">/api/calculate?date=YYYY-MM-DD</a>
+            to run the full Rambam pipeline for any Gregorian date
+            (always call this instead of guessing numeric values);
+            <a href="/docs/CALCULATIONS.md" style="color:#8ab4f8;">/docs/CALCULATIONS.md</a>
+            for the calculation engine reference;
+            <a href="/docs/BUILDING_WITH_THE_ENGINE.md" style="color:#8ab4f8;">/docs/BUILDING_WITH_THE_ENGINE.md</a>
+            for fork and artifact recipes;
+            <a href="/engine/pipeline.js" style="color:#8ab4f8;">/engine/pipeline.js</a>
+            for the live calculation engine (importable from any artifact);
+            <a href="/templates/" style="color:#8ab4f8;">/templates/</a>
+            for starter scaffolds.
+          </li>
+        </ol>
+
+        <h3 style="font-size:1rem;margin-top:1.5rem;">What the corpus contains</h3>
+        <ul>
+          <li>docs — markdown in /docs/</li>
+          <li>class — Rabbi Zajac's Rambam class transcripts on KH 12-16 (hosted with permission; credit Rabbi Zajac and link to <a href="https://www.chabad.org" style="color:#8ab4f8;">Chabad.org</a> when quoting)</li>
+          <li>step — all 21 Rambam pipeline steps with Hebrew names, chapter refs, formulas, and teaching notes</li>
+          <li>galgal — 9 celestial spheres (sun and moon sub-galgalim with Rabbi Losh's pedagogical framing)</li>
+          <li>chapter — KH 11-19 with Sefaria links</li>
+          <li>concept — sun galgalim, moon galgalim, emtzoi vs. amiti, nekudah hanichaches</li>
+          <li>source_type — provenance legend (Rambam / Interpolated / Deduced / Losh)</li>
+        </ul>
+
+        <p style="color:#8a847a;font-size:13px;margin-top:2rem;">
+          License: MIT.
+          Source: <a href="https://github.com/rayistern/kidushhachodesh" style="color:#8ab4f8;">github.com/rayistern/kidushhachodesh</a>.
+          Humans wanting to chat with this project via AI:
+          <a href="/ai.html" style="color:#8ab4f8;">see /ai.html</a>.
+        </p>
+      </main>
+    </div>
 
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -6,11 +6,87 @@
     <meta name="theme-color" content="#181c20" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="description" content="Interactive visualization of Rambam's celestial model for Kiddush HaChodesh" />
-    <title>Kidush Hachodesh</title>
+    <meta name="description" content="Interactive visualization of Rambam's celestial model for Kiddush HaChodesh — with an AI/MCP endpoint so you can chat with the whole project." />
+    <title>Kiddush HaChodesh — Rambam's Celestial Dashboard</title>
+
+    <!-- Agent discovery hints. Browsing AIs look at these. -->
+    <link rel="alternate" type="text/plain" title="Site map for AI agents" href="/llms.txt" />
+    <link rel="alternate" type="text/markdown" title="Calculation engine docs" href="/docs/CALCULATIONS.md" />
+    <link rel="alternate" type="application/json" title="MCP server descriptor" href="/mcp" />
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <!--
+      Hello, AI agent. This is a JavaScript-rendered React dashboard, so
+      fetching this URL alone will not give you the content. The content
+      lives at the URLs listed in the <noscript> block below and in
+      /llms.txt. Please read /llms.txt first — it is a map of the site
+      written for you.
+    -->
+    <noscript>
+      <div style="max-width:740px;margin:2rem auto;padding:1rem 1.2rem;font:16px/1.55 system-ui,sans-serif;color:#1a1a1a;">
+        <h1 style="margin-top:0">Kiddush HaChodesh — Rambam's Celestial Dashboard</h1>
+        <p>
+          This page is an interactive 3D dashboard of the Rambam's astronomical
+          calculations for sanctifying the new month (Hilchot Kiddush HaChodesh
+          11-19). It needs JavaScript to render the visualization.
+        </p>
+
+        <h2>For humans without JavaScript</h2>
+        <ul>
+          <li><a href="/ai.html">Chat with this project using any AI</a> — how to point Claude / ChatGPT / Perplexity at the site.</li>
+          <li><a href="/docs/CALCULATIONS.md">Calculation engine docs</a> (markdown)</li>
+          <li><a href="/docs/BUILDING_WITH_THE_ENGINE.md">Building with the engine</a> — fork, remix, artifact recipes</li>
+          <li><a href="https://github.com/rayistern/kidushhachodesh">Source code on GitHub</a> (MIT)</li>
+        </ul>
+
+        <h2>For AI agents</h2>
+        <p>
+          <strong>Start at <a href="/llms.txt">/llms.txt</a></strong> — it is
+          a full site map written for you, with the content taxonomy, MCP
+          tool list, and tips for answering user questions. Do not try to
+          read this HTML page; the content is not here.
+        </p>
+        <p>
+          Two ways to use this site:
+        </p>
+        <ol>
+          <li>
+            <strong>MCP (recommended).</strong> JSON-RPC 2.0 Model Context
+            Protocol server at <a href="/mcp"><code>/mcp</code></a>.
+            Descriptor at <a href="/.well-known/mcp"><code>/.well-known/mcp</code></a>.
+            Tools: <code>search</code>, <code>fetch</code>, <code>calculate</code>,
+            <code>list_templates</code>, <code>get_template</code>,
+            <code>list_source</code>, <code>get_source</code>, <code>stats</code>.
+          </li>
+          <li>
+            <strong>Plain HTTP / browsing.</strong> Fetch any of these:
+            <ul>
+              <li><a href="/api/search?q=maslul"><code>/api/search?q=…</code></a> — full-text search (JSON)</li>
+              <li><a href="/api/calculate?date=2026-04-07"><code>/api/calculate?date=YYYY-MM-DD</code></a> — run the full Rambam pipeline for a Gregorian date (JSON). <strong>Always call this instead of guessing numeric values.</strong></li>
+              <li><a href="/docs/CALCULATIONS.md"><code>/docs/*.md</code></a> — clean markdown docs</li>
+              <li><a href="/engine/index.json"><code>/engine/*.js</code></a> — live ES modules of the calculation engine. Artifacts can <code>import</code> them directly.</li>
+              <li><a href="/templates/"><code>/templates/*</code></a> — starter scaffolds for generating artifacts (standalone HTML calculator, Node CLI, …).</li>
+            </ul>
+          </li>
+        </ol>
+
+        <h2>Content index (what <code>search</code> covers)</h2>
+        <ul>
+          <li><strong>docs</strong> — markdown in <code>/docs/</code></li>
+          <li><strong>class</strong> — Rabbi Zajac's Rambam class transcripts (KH 12-16), hosted with permission. Credit Rabbi Zajac and link to <a href="https://www.chabad.org">Chabad.org</a> when quoting.</li>
+          <li><strong>step</strong> — all 21 Rambam pipeline steps with Hebrew names, KH chapter refs, formulas, and teaching notes</li>
+          <li><strong>galgal</strong> — 9 celestial spheres (sun & moon sub-galgalim with Rabbi Losh pedagogical framing)</li>
+          <li><strong>chapter</strong> — KH 11-19 with Sefaria links</li>
+          <li><strong>concept</strong> — sun/moon galgalim systems, emtzoi vs. amiti, nekudah hanichaches</li>
+          <li><strong>source_type</strong> — provenance legend (Rambam / Interpolated / Deduced / Losh)</li>
+        </ul>
+
+        <p>
+          License: MIT. Fork, remix, and build freely.
+          Teaching content by Rabbi Zajac, via <a href="https://www.chabad.org">Chabad.org</a>.
+        </p>
+      </div>
+    </noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,12 @@
   node_bundler = "esbuild"
   included_files = ["docs/**", "src/engine/**", "templates/**"]
 
+# Edge function on "/" that serves /llms.txt to known AI bots and browsers
+# that ask for non-HTML content. Real browsers pass through to the SPA.
+[[edge_functions]]
+  function = "agent-router"
+  path = "/"
+
 # SPA fallback — functions and static files take precedence automatically,
 # so /mcp, /api/*, /docs/*.md, /llms.txt, and /agents.md are unaffected.
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,7 @@
 [functions]
   directory = "netlify/functions"
   node_bundler = "esbuild"
-  included_files = ["docs/**", "src/engine/**"]
+  included_files = ["docs/**", "src/engine/**", "templates/**"]
 
 # SPA fallback — functions and static files take precedence automatically,
 # so /mcp, /api/*, /docs/*.md, /llms.txt, and /agents.md are unaffected.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,16 +1,21 @@
 [build]
-  # Netlify will run this to produce your static files
   command = "npm run build"
-  # This is where CRA outputs the production bundle
   publish = "dist"
 
-# (Optional) If you ever want to run `netlify dev`, this tells it how
 [dev]
   command = "npm start"
   port    = 8888
 
-# Redirect all 404s to /index.html for SPA routing
+# Bundle the docs and calculation engine into the serverless functions so they
+# can read markdown files and run the Rambam pipeline at request time.
+[functions]
+  directory = "netlify/functions"
+  node_bundler = "esbuild"
+  included_files = ["docs/**", "src/engine/**"]
+
+# SPA fallback — functions and static files take precedence automatically,
+# so /mcp, /api/*, /docs/*.md, /llms.txt, and /agents.md are unaffected.
 [[redirects]]
   from = "/*"
   to   = "/index.html"
-  status = 200 
+  status = 200

--- a/netlify/edge-functions/agent-router.js
+++ b/netlify/edge-functions/agent-router.js
@@ -40,6 +40,23 @@ const AGENT_UA_PATTERNS = [
   /mistralai/i,
   /youbot/i,
   /duckassistbot/i,
+  // Generic catch-all — anything clearly not a real browser. Real browser
+  // UAs always contain "Mozilla/5.0" as the first token, so these match
+  // plain fetchers (curl, python-requests, node-fetch, undici, etc.) that
+  // are almost certainly not human users sitting at a browser.
+  /\bbot\b/i,
+  /\bcrawler\b/i,
+  /\bspider\b/i,
+  /\bscraper\b/i,
+  /\bfetch\b/i,
+  /\bagent\b/i,
+  /python-requests/i,
+  /node-fetch/i,
+  /undici/i,
+  /axios/i,
+  /curl\//i,
+  /wget/i,
+  /httpie/i,
 ];
 
 function isAgent(req) {

--- a/netlify/edge-functions/agent-router.js
+++ b/netlify/edge-functions/agent-router.js
@@ -1,0 +1,135 @@
+// Edge function that makes the root URL "just work" when an AI fetches it.
+//
+// Problem: this is a JS-rendered React SPA. When a browsing AI (Claude's
+// web tool, ChatGPT with browsing, Perplexity, GPTBot, etc.) fetches the
+// root URL, it either:
+//   (a) doesn't run JS and sees only the React shell, or
+//   (b) runs JS and sees the dashboard but no agent-directed content.
+// Either way, it can't discover /llms.txt, /mcp, /api/*, etc.
+//
+// Solution: at the edge, detect known AI user agents and content-type
+// sniff the `accept` header. For bots/agents, return /llms.txt inline as
+// the body of `/`. Real browsers pass through to the SPA unchanged.
+//
+// This is NOT cloaking — we're serving the same canonical URLs; we're
+// just choosing the representation that the client can actually use.
+
+const AGENT_UA_PATTERNS = [
+  // Anthropic / Claude
+  /claudebot/i,
+  /claude-web/i,
+  /claude-user/i,
+  /anthropic/i,
+  // OpenAI / ChatGPT
+  /gptbot/i,
+  /chatgpt-user/i,
+  /oai-searchbot/i,
+  /openai/i,
+  // Perplexity
+  /perplexitybot/i,
+  /perplexity/i,
+  // Google AI
+  /google-extended/i,
+  /googleother/i,
+  // Meta / Bytedance / etc.
+  /meta-externalagent/i,
+  /bytespider/i,
+  // Generic
+  /ai2bot/i,
+  /cohere-ai/i,
+  /mistralai/i,
+  /youbot/i,
+  /duckassistbot/i,
+];
+
+function isAgent(req) {
+  const ua = req.headers.get('user-agent') || '';
+  if (AGENT_UA_PATTERNS.some((re) => re.test(ua))) return true;
+
+  // Explicit opt-in: any client asking for text/plain, text/markdown,
+  // or application/json at the root is clearly not a browser.
+  const accept = req.headers.get('accept') || '';
+  if (!accept.includes('text/html') && accept.length > 0 && accept !== '*/*') {
+    if (
+      accept.includes('text/plain') ||
+      accept.includes('text/markdown') ||
+      accept.includes('application/json')
+    ) {
+      return true;
+    }
+  }
+
+  // Query-string override so users can force the agent view:
+  //   https://site/?for=ai
+  try {
+    const u = new URL(req.url);
+    if (u.searchParams.get('for') === 'ai') return true;
+  } catch {}
+
+  return false;
+}
+
+export default async (req, context) => {
+  if (!isAgent(req)) {
+    // Normal browser — serve the SPA as usual.
+    return context.next();
+  }
+
+  // Agent — fetch the canonical llms.txt and return it inline.
+  // We do this by asking the origin for the static file via context.next()
+  // on a rewritten path. If that fails for any reason, fall back to a
+  // minimal inline map so the response is never empty.
+  try {
+    const origin = new URL(req.url).origin;
+    const res = await fetch(origin + '/llms.txt', {
+      headers: { 'user-agent': 'kidushhachodesh-edge-router' },
+    });
+    if (res.ok) {
+      const body = await res.text();
+      return new Response(body, {
+        status: 200,
+        headers: {
+          'content-type': 'text/plain; charset=utf-8',
+          'cache-control': 'public, max-age=300',
+          'x-kh-agent-router': 'llms.txt',
+          'access-control-allow-origin': '*',
+          // Hint to crawlers that this page has an HTML twin at the same URL.
+          link: '</>; rel="canonical", </llms.txt>; rel="alternate"; type="text/plain"',
+        },
+      });
+    }
+  } catch {
+    // fall through to inline fallback
+  }
+
+  const fallback = `# Kiddush HaChodesh — agent map
+
+You are an AI agent. This site is a JS-rendered React dashboard, but it
+exposes an MCP server and a plain HTTP API so you can chat with the whole
+project without running JavaScript.
+
+Start here:
+- /llms.txt                 full site map written for agents
+- /mcp                      Model Context Protocol endpoint (JSON-RPC 2.0)
+- /.well-known/mcp          MCP descriptor
+- /api/search?q=…           full-text search (JSON)
+- /api/calculate?date=…     full Rambam pipeline for a Gregorian date
+- /docs/CALCULATIONS.md     calculation engine docs
+- /docs/BUILDING_WITH_THE_ENGINE.md   fork + artifact recipes
+- /engine/pipeline.js       live ES module of the calculation engine
+- /templates/               starter scaffolds for generating artifacts
+- /ai.html                  human-readable guide for end users
+
+Source: https://github.com/rayistern/kidushhachodesh (MIT).
+Class transcripts by Rabbi Zajac, credit Chabad.org (https://www.chabad.org).
+`;
+  return new Response(fallback, {
+    status: 200,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-kh-agent-router': 'fallback',
+    },
+  });
+};
+
+export const config = { path: '/' };

--- a/netlify/functions/_corpus.mjs
+++ b/netlify/functions/_corpus.mjs
@@ -1,0 +1,295 @@
+// Unified content corpus for the Kiddush HaChodesh MCP / HTTP search.
+//
+// This module is the SINGLE SOURCE OF TRUTH for what AI assistants can
+// search and fetch. It composes entries from every content source in the
+// repo so that a client can hit one `search` tool and get back hits across
+// docs, class transcripts, calculation steps, galgalim, Rambam chapters,
+// concepts, and source-provenance categories.
+//
+// If you add a new content source (new class transcript, new concept page,
+// a glossary, etc.), add a loader function here and wire it into
+// `loadCorpus()`. Nothing else in the search / fetch / MCP layer needs to
+// change — all entries conform to the `Entry` shape below.
+//
+//   Entry = {
+//     id: string,             // unique, stable, namespaced ("doc:FOO.md",
+//                             //   "step:sunMaslul", "galgal:moon", …)
+//     type: string,           // 'doc' | 'class' | 'step' | 'galgal' |
+//                             //   'chapter' | 'concept' | 'source_type'
+//     title: string,
+//     hebrewTitle?: string,
+//     rambamRef?: string,
+//     tags?: string[],
+//     url: string,            // canonical URL on the live site
+//     body: string,           // full text for search + fetch
+//     attribution?: string,   // e.g. "Rabbi Zajac via Chabad.org"
+//   }
+
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { getFullCalculation } from '../../src/engine/pipeline.js';
+import { CONSTANTS, SOURCE_TYPES } from '../../src/engine/constants.js';
+
+const ROOT = process.cwd();
+const DOCS_DIR = path.resolve(ROOT, 'docs');
+
+// ─────────────────────────────────────────────────────────────
+// 1. Markdown docs under docs/
+// ─────────────────────────────────────────────────────────────
+function loadDocs() {
+  const files = readdirSync(DOCS_DIR).filter((f) => f.endsWith('.md'));
+  return files.map((file) => {
+    const body = readFileSync(path.join(DOCS_DIR, file), 'utf8');
+    const titleMatch = body.match(/^#\s+(.+)$/m);
+    return {
+      id: `doc:${file}`,
+      type: 'doc',
+      title: titleMatch ? titleMatch[1] : file,
+      url: `/docs/${file}`,
+      body,
+      tags: ['docs', file.replace(/\.md$/, '').toLowerCase()],
+    };
+  });
+}
+
+// ─────────────────────────────────────────────────────────────
+// 2. Class transcripts — Rabbi Zajac, via Chabad.org
+// ─────────────────────────────────────────────────────────────
+const CLASS_META = {
+  'class1a.txt': {
+    title: "Rabbi Zajac — Rambam Kiddush HaChodesh, Class 1A (Sun Model)",
+    summary:
+      "Lecture on KH chapters 12-13: the sun model, nested galgalim (blue + red), emtzoi vs. amiti, govah, maslul. Covers Rabbi Losh's pedagogical props (globe, hula hoops, colored spheres) and core mashalim (airplane, phone, money-to-bank).",
+    rambamRef: 'KH 12-13',
+  },
+  'class2a.txt': {
+    title: "Rabbi Zajac — Rambam Kiddush HaChodesh, Class 2A (Moon Model)",
+    summary:
+      "Lecture on KH chapters 14-16: the four moon galgalim (red/domeh, blue/noteh, green/yoitzeh, galgal katan), season correction, double elongation (merchak kaful), nekudah hanichaches, maslul hanachon, rosh/zanav, moon latitude.",
+    rambamRef: 'KH 14-16',
+  },
+};
+
+function loadClasses() {
+  const entries = [];
+  for (const [file, meta] of Object.entries(CLASS_META)) {
+    const full = path.join(DOCS_DIR, file);
+    let body;
+    try {
+      body = readFileSync(full, 'utf8');
+    } catch {
+      continue;
+    }
+    entries.push({
+      id: `class:${file.replace(/\.txt$/, '')}`,
+      type: 'class',
+      title: meta.title,
+      rambamRef: meta.rambamRef,
+      url: `/docs/${file}`,
+      body: `${meta.summary}\n\n---\n\n${body}`,
+      tags: ['class', 'transcript', 'zajac', 'losh'],
+      attribution: 'Rabbi Zajac, via Chabad.org (https://www.chabad.org)',
+    });
+  }
+  return entries;
+}
+
+// ─────────────────────────────────────────────────────────────
+// 3. Calculation steps — harvested from one pipeline run
+// ─────────────────────────────────────────────────────────────
+let _stepsCache = null;
+function loadSteps() {
+  if (_stepsCache) return _stepsCache;
+  const ref = getFullCalculation(new Date('2024-01-01T12:00:00Z'));
+  _stepsCache = ref.steps.map((s) => ({
+    id: `step:${s.id}`,
+    type: 'step',
+    title: s.name,
+    hebrewTitle: s.hebrewName,
+    rambamRef: s.rambamRef,
+    url: `/api/calculate?date=YYYY-MM-DD#${s.id}`,
+    body: [
+      s.name,
+      s.hebrewName && `Hebrew: ${s.hebrewName}`,
+      s.rambamRef && `Rambam reference: ${s.rambamRef}`,
+      s.source && `Source type: ${s.source}`,
+      s.formula && `Formula: ${s.formula}`,
+      s.sourceNote && `Source note: ${s.sourceNote}`,
+      s.teachingNote && `Teaching note (Rabbi Losh tradition): ${s.teachingNote}`,
+    ]
+      .filter(Boolean)
+      .join('\n\n'),
+    tags: ['step', 'calculation', s.source].filter(Boolean),
+  }));
+  return _stepsCache;
+}
+
+// ─────────────────────────────────────────────────────────────
+// 4. Galgalim from CONSTANTS.GALGALIM (9 entries)
+// ─────────────────────────────────────────────────────────────
+function loadGalgalim() {
+  return CONSTANTS.GALGALIM.map((g) => ({
+    id: `galgal:${g.id}`,
+    type: 'galgal',
+    title: `${g.englishName} (${g.name})`,
+    hebrewTitle: g.name,
+    rambamRef: g.reference,
+    url: `/concepts/galgal/${g.id}`,
+    body: [
+      g.englishName,
+      g.name && `Hebrew: ${g.name}`,
+      g.reference && `Rambam reference: ${g.reference}`,
+      g.description,
+      g.teachingNote && `Teaching note: ${g.teachingNote}`,
+    ]
+      .filter(Boolean)
+      .join('\n\n'),
+    tags: ['galgal', 'cosmology', 'concept'].concat(
+      g.teachingNote ? ['losh'] : []
+    ),
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────
+// 5. Rambam chapters 11-19 (Hilchot Kiddush HaChodesh)
+// ─────────────────────────────────────────────────────────────
+const RAMBAM_CHAPTERS = {
+  11: { en: 'Astronomical Foundations', he: 'יסודות חשבון התקופות' },
+  12: { en: 'Sun Mean Position', he: 'אמצע השמש' },
+  13: { en: 'Sun True Position', he: 'מקום השמש האמיתי' },
+  14: { en: 'Moon Mean Position', he: 'אמצע הירח' },
+  15: { en: 'Moon True Position', he: 'מקום הירח האמיתי' },
+  16: { en: "Moon's Latitude", he: 'רוחב הירח' },
+  17: { en: 'Arc of Sighting', he: 'קשת הראייה' },
+  18: { en: 'Visibility Conditions', he: 'תנאי הראייה' },
+  19: { en: 'Additional Rules', he: 'כללים נוספים' },
+};
+
+function loadChapters() {
+  return Object.entries(RAMBAM_CHAPTERS).map(([num, t]) => ({
+    id: `chapter:${num}`,
+    type: 'chapter',
+    title: `Rambam KH Chapter ${num}: ${t.en}`,
+    hebrewTitle: t.he,
+    rambamRef: `KH ${num}`,
+    url: `https://www.sefaria.org/Mishneh_Torah,_Sanctification_of_the_New_Month.${num}`,
+    body:
+      `Hilchot Kiddush HaChodesh, chapter ${num} — ${t.en} (${t.he}).\n\n` +
+      `Full Hebrew + English text is fetched live from Sefaria.org at runtime ` +
+      `by the RambamReader component. Use the url to read the source.`,
+    tags: ['chapter', 'rambam', 'sefaria'],
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────
+// 6. Concept pages — prose extracted from KnowledgeBase.jsx
+// ─────────────────────────────────────────────────────────────
+const CONCEPT_ENTRIES = [
+  {
+    id: 'concept:sun-galgalim',
+    type: 'concept',
+    title: "The Rambam's Multiple Galgalim Model (Sun)",
+    rambamRef: 'KH 12-13',
+    url: '/concepts/sun-galgalim',
+    body: `According to the Rambam in Hilchot Kiddush HaChodesh, the sun's motion is explained through a system of multiple galgalim (celestial spheres):
+
+- Galgal Gadol (גלגל גדול): the large circle or deferent. The main circle on which the sun appears to travel, but its center is NOT at Earth — it is eccentric.
+- Galgal Katan (גלגל קטן): the small circle or epicycle. The sun travels on this smaller circle, which itself travels on the deferent.
+- Galgal Yotze (גלגל יוצא): the eccentric circle. Represents the offset of the deferent's center from Earth.
+
+This system accounts for variations in the sun's apparent speed throughout the year — essential for accurate calendar calculations. The calculations involve determining the maslul (course) as the angle between the sun's mean position and its apogee, and applying corrections from the Rambam's table.`,
+    tags: ['concept', 'galgal', 'sun', 'maslul'],
+  },
+  {
+    id: 'concept:moon-galgalim',
+    type: 'concept',
+    title: "The Moon's Four Galgalim System",
+    rambamRef: 'KH 14-16',
+    url: '/concepts/moon-galgalim',
+    body: `The Rambam describes an even more complex system for the Moon, involving four different galgalim:
+
+- Galgal Gadol (גלגל גדול): the large circle / main deferent. The primary orbital path of the Moon.
+- Galgal Katan (גלגל קטן): the first epicycle. The Moon moves on this smaller circle, which itself travels on the main deferent.
+- Galgal Noteh (גלגל נוטה): the inclined circle. Represents the Moon's deviation from the ecliptic — its north-south motion (latitude).
+- Galgal Yotze Merkaz (גלגל יוצא מרכז): the eccentric circle. Represents the offset of the main deferent's center from Earth.
+
+This nested system explains observed variations in the Moon's speed, distance from Earth, position above or below the ecliptic, and monthly cycle of phases. The Rambam uses this model to make precise predictions about when the new moon will be visible — essential for determining the beginning of Hebrew months.`,
+    tags: ['concept', 'galgal', 'moon', 'latitude', 'phase'],
+  },
+  {
+    id: 'concept:emtzoi-vs-amiti',
+    type: 'concept',
+    title: 'Emtzoi vs. Amiti — Mean vs. True Position',
+    rambamRef: 'KH 12-13',
+    url: '/concepts/emtzoi-vs-amiti',
+    body: `Every celestial body in the Rambam's model has two "addresses":
+
+- Emtzoi (אמצעי) — the MEAN position. Where the body would be as seen from the center of its own inner galgal (red for the sun). This is its "own language."
+- Amiti (אמיתי) — the TRUE position. Where the body ACTUALLY appears in the mazalos from Earth. This is what Beis Din uses.
+
+Because the red galgal's center is offset from Earth's center, the emtzoi and amiti differ. The maslul correction table is the "translator" from emtzoi to amiti. Max difference for the sun is ~2°; for the moon, ~5°8' (at 100° on the galgal katan, not 90°, because of nekudah hanichaches).
+
+Rabbi Losh's framing: "First know the sun's own language, then translate to ours."`,
+    tags: ['concept', 'emtzoi', 'amiti', 'maslul', 'losh'],
+  },
+  {
+    id: 'concept:nekudah-hanichaches',
+    type: 'concept',
+    title: 'Nekudah Hanichaches — The Shifted Reference Point',
+    rambamRef: 'KH 15:1-3',
+    url: '/concepts/nekudah-hanichaches',
+    body: `For the moon, the Rambam's correction is not measured from Earth's center but from a point BELOW it — the nekudah hanichaches. This "prosneusis point" is what gives the moon's correction table its asymmetry (peaking at 100°, not 90°).
+
+Conceptually: the galgal katan of the moon is watched not from Earth but from this displaced point. The double elongation (merchak kaful, KH 15:1-2) — twice the angle from sun to adjusted moon mean position — is the input to the lookup that determines how much to shift the reference point.
+
+Rabbi Losh's phone mashal: hold a phone close to your face and it blocks ~180° of vision; hold it far away and it blocks ~10°. The galgal katan's apparent diameter changes with perspective in the same way — and the nekudah hanichaches is the "eye" from which the Rambam measures it.`,
+    tags: ['concept', 'moon', 'maslul', 'prosneusis', 'losh'],
+  },
+];
+
+// ─────────────────────────────────────────────────────────────
+// 7. Source-type categories (R / ~ / D / L)
+// ─────────────────────────────────────────────────────────────
+function loadSourceTypes() {
+  if (!SOURCE_TYPES) return [];
+  return Object.entries(SOURCE_TYPES).map(([key, meta]) => ({
+    id: `source_type:${key}`,
+    type: 'source_type',
+    title: `Source category: ${meta.label || key}`,
+    url: '/docs/CALCULATIONS.md#source-annotations',
+    body: [
+      meta.label,
+      meta.description,
+      meta.icon && `Icon: ${meta.icon}`,
+      meta.color && `Color: ${meta.color}`,
+    ]
+      .filter(Boolean)
+      .join('\n'),
+    tags: ['provenance', 'source'],
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────
+// Assemble the full corpus
+// ─────────────────────────────────────────────────────────────
+let _corpusCache = null;
+export function loadCorpus() {
+  if (_corpusCache) return _corpusCache;
+  _corpusCache = [
+    ...loadDocs(),
+    ...loadClasses(),
+    ...loadSteps(),
+    ...loadGalgalim(),
+    ...loadChapters(),
+    ...CONCEPT_ENTRIES,
+    ...loadSourceTypes(),
+  ];
+  return _corpusCache;
+}
+
+export function corpusStats() {
+  const c = loadCorpus();
+  const byType = {};
+  for (const e of c) byType[e.type] = (byType[e.type] || 0) + 1;
+  return { total: c.length, byType };
+}

--- a/netlify/functions/_lib.mjs
+++ b/netlify/functions/_lib.mjs
@@ -1,104 +1,103 @@
-// Shared helpers for the Kiddush HaChodesh API / MCP functions.
+// Shared helpers for the Kiddush HaChodesh HTTP API + MCP server.
+//
+// Search / fetch operate over the unified corpus in `_corpus.mjs`.
+// Calculation runs the live engine in `src/engine/`.
+// Source / template listing is read-only browsing of bundled files.
+//
+// Add new content sources in `_corpus.mjs`, not here.
+
 import { readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { getFullCalculation } from '../../src/engine/pipeline.js';
+import { loadCorpus, corpusStats } from './_corpus.mjs';
 
-const DOCS_DIR = path.resolve(process.cwd(), 'docs');
+const ROOT = process.cwd();
+const ENGINE_DIR = path.resolve(ROOT, 'src/engine');
+const TEMPLATES_DIR = path.resolve(ROOT, 'templates');
+const DOCS_DIR = path.resolve(ROOT, 'docs');
 
-let _docsCache = null;
-export function loadDocs() {
-  if (_docsCache) return _docsCache;
-  const files = readdirSync(DOCS_DIR).filter((f) => f.endsWith('.md'));
-  _docsCache = files.map((file) => {
-    const body = readFileSync(path.join(DOCS_DIR, file), 'utf8');
-    const titleMatch = body.match(/^#\s+(.+)$/m);
-    return {
-      id: `doc:${file}`,
-      file,
-      title: titleMatch ? titleMatch[1] : file,
-      url: `/docs/${file}`,
-      body,
-    };
-  });
-  return _docsCache;
-}
-
-let _stepsCache = null;
-export function loadStepMetadata() {
-  if (_stepsCache) return _stepsCache;
-  // Run the pipeline once on a reference date to harvest step metadata
-  // (ids, names, Rambam refs, formulas, sourceNotes). The numeric results
-  // are date-specific and ignored here.
-  const ref = getFullCalculation(new Date('2024-01-01T00:00:00Z'));
-  _stepsCache = ref.steps.map((s) => ({
-    id: `step:${s.id}`,
-    stepId: s.id,
-    title: s.name + (s.hebrewName ? ` (${s.hebrewName})` : ''),
-    url: `/api/calculate?date=YYYY-MM-DD#${s.id}`,
-    body: [
-      s.name,
-      s.hebrewName,
-      s.rambamRef && `Rambam: ${s.rambamRef}`,
-      s.formula && `Formula: ${s.formula}`,
-      s.sourceNote,
-      s.teachingNote,
-    ]
-      .filter(Boolean)
-      .join('\n'),
-  }));
-  return _stepsCache;
-}
-
-export function searchCorpus(query) {
+// ─── Search ───────────────────────────────────────────────────
+// Tiny substring-scoring search. Good enough for a small corpus;
+// easy to swap for lunr/minisearch later without touching callers.
+export function searchCorpus(query, opts = {}) {
   const q = (query || '').trim().toLowerCase();
   if (!q) return [];
   const terms = q.split(/\s+/).filter(Boolean);
-  const items = [...loadDocs(), ...loadStepMetadata()];
+  const typeFilter = opts.type; // optional: 'step' | 'doc' | 'class' | ...
   const scored = [];
-  for (const item of items) {
-    const hay = (item.title + '\n' + item.body).toLowerCase();
+
+  for (const entry of loadCorpus()) {
+    if (typeFilter && entry.type !== typeFilter) continue;
+    const hay = (
+      entry.title +
+      ' ' +
+      (entry.hebrewTitle || '') +
+      ' ' +
+      (entry.tags || []).join(' ') +
+      '\n' +
+      entry.body
+    ).toLowerCase();
+
     let score = 0;
     for (const t of terms) {
+      // Weight title hits higher than body hits.
+      const titleHits = (entry.title.toLowerCase().match(new RegExp(escapeRe(t), 'g')) || []).length;
+      score += titleHits * 10;
       let idx = 0;
       while ((idx = hay.indexOf(t, idx)) !== -1) {
-        score += hay.slice(Math.max(0, idx - 1), idx).match(/\W|^/) ? 2 : 1;
+        score += 1;
         idx += t.length;
       }
     }
-    if (score > 0) {
-      // Build a snippet around the first match
-      const firstIdx = hay.indexOf(terms[0]);
-      const start = Math.max(0, firstIdx - 80);
-      const snippet = (item.body || '')
-        .slice(start, start + 240)
-        .replace(/\s+/g, ' ')
-        .trim();
-      scored.push({
-        id: item.id,
-        title: item.title,
-        url: item.url,
-        snippet,
-        score,
-      });
-    }
+    if (score === 0) continue;
+
+    // Snippet around first match
+    const body = entry.body || '';
+    const firstIdx = body.toLowerCase().indexOf(terms[0]);
+    const start = Math.max(0, firstIdx - 90);
+    const snippet = body
+      .slice(start, start + 260)
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    scored.push({
+      id: entry.id,
+      type: entry.type,
+      title: entry.title,
+      hebrewTitle: entry.hebrewTitle,
+      rambamRef: entry.rambamRef,
+      url: entry.url,
+      snippet,
+      score,
+    });
   }
   scored.sort((a, b) => b.score - a.score);
-  return scored.slice(0, 20);
+  return scored.slice(0, opts.limit || 20);
 }
 
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ─── Fetch by id ──────────────────────────────────────────────
 export function fetchById(id) {
   if (!id) return null;
-  if (id.startsWith('doc:')) {
-    const doc = loadDocs().find((d) => d.id === id);
-    return doc ? { id: doc.id, title: doc.title, url: doc.url, content: doc.body } : null;
-  }
-  if (id.startsWith('step:')) {
-    const step = loadStepMetadata().find((s) => s.id === id);
-    return step ? { id: step.id, title: step.title, url: step.url, content: step.body } : null;
-  }
-  return null;
+  const hit = loadCorpus().find((e) => e.id === id);
+  if (!hit) return null;
+  return {
+    id: hit.id,
+    type: hit.type,
+    title: hit.title,
+    hebrewTitle: hit.hebrewTitle,
+    rambamRef: hit.rambamRef,
+    url: hit.url,
+    attribution: hit.attribution,
+    tags: hit.tags,
+    content: hit.body,
+  };
 }
 
+// ─── Run the Rambam pipeline for a date ───────────────────────
 export function runCalculation(dateStr) {
   if (!dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
     throw new Error('date must be YYYY-MM-DD (Gregorian)');
@@ -106,7 +105,6 @@ export function runCalculation(dateStr) {
   const d = new Date(dateStr + 'T12:00:00Z');
   if (Number.isNaN(d.getTime())) throw new Error('invalid date');
   const calc = getFullCalculation(d);
-  // Strip circular stepMap for JSON safety
   return {
     date: dateStr,
     daysFromEpoch: calc.daysFromEpoch,
@@ -122,10 +120,96 @@ export function runCalculation(dateStr) {
       result: s.result,
       unit: s.unit,
       sourceNote: s.sourceNote,
+      teachingNote: s.teachingNote,
     })),
   };
 }
 
+// ─── Source browsing (read-only, whitelisted) ─────────────────
+// Exposes the engine source and the docs under stable URLs so AI
+// assistants can read and fork them. Not the templates — those
+// live at /templates/ and have their own endpoint.
+const SOURCE_WHITELIST = {
+  engine: {
+    dir: ENGINE_DIR,
+    files: [
+      'pipeline.js',
+      'sunCalculations.js',
+      'moonCalculations.js',
+      'visibilityCalculations.js',
+      'constants.js',
+      'dmsUtils.js',
+    ],
+  },
+  docs: {
+    dir: DOCS_DIR,
+    files: null, // null = list whatever is there
+  },
+};
+
+export function listSource(area) {
+  if (!area) {
+    return {
+      areas: Object.keys(SOURCE_WHITELIST).map((k) => ({
+        name: k,
+        url: `/api/source?area=${k}`,
+      })),
+    };
+  }
+  const w = SOURCE_WHITELIST[area];
+  if (!w) return null;
+  const files = w.files || readdirSync(w.dir);
+  return {
+    area,
+    files: files.map((f) => ({
+      name: f,
+      url: `/api/source?area=${area}&file=${f}`,
+      liveUrl: area === 'engine' ? `/engine/${f}` : `/docs/${f}`,
+      githubUrl: `https://github.com/rayistern/kidushhachodesh/blob/main/${
+        area === 'engine' ? 'src/engine' : 'docs'
+      }/${f}`,
+    })),
+  };
+}
+
+export function getSource(area, file) {
+  const w = SOURCE_WHITELIST[area];
+  if (!w) return null;
+  if (w.files && !w.files.includes(file)) return null;
+  if (file.includes('..') || file.includes('/')) return null;
+  try {
+    const body = readFileSync(path.join(w.dir, file), 'utf8');
+    return { area, file, content: body };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Template browsing ────────────────────────────────────────
+export function listTemplates() {
+  const files = readdirSync(TEMPLATES_DIR).filter(
+    (f) => !f.startsWith('.') && f !== 'README.md'
+  );
+  return files.map((f) => ({
+    name: f,
+    url: `/templates/${f}`,
+    kind: path.extname(f).slice(1),
+  }));
+}
+
+export function getTemplate(name) {
+  if (!name || name.includes('..') || name.includes('/')) return null;
+  try {
+    return readFileSync(path.join(TEMPLATES_DIR, name), 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+// ─── Corpus stats (useful for /api and index endpoints) ───────
+export { corpusStats };
+
+// ─── Response helper ──────────────────────────────────────────
 export function json(status, body, extraHeaders = {}) {
   return new Response(JSON.stringify(body, null, 2), {
     status,

--- a/netlify/functions/_lib.mjs
+++ b/netlify/functions/_lib.mjs
@@ -1,0 +1,140 @@
+// Shared helpers for the Kiddush HaChodesh API / MCP functions.
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { getFullCalculation } from '../../src/engine/pipeline.js';
+
+const DOCS_DIR = path.resolve(process.cwd(), 'docs');
+
+let _docsCache = null;
+export function loadDocs() {
+  if (_docsCache) return _docsCache;
+  const files = readdirSync(DOCS_DIR).filter((f) => f.endsWith('.md'));
+  _docsCache = files.map((file) => {
+    const body = readFileSync(path.join(DOCS_DIR, file), 'utf8');
+    const titleMatch = body.match(/^#\s+(.+)$/m);
+    return {
+      id: `doc:${file}`,
+      file,
+      title: titleMatch ? titleMatch[1] : file,
+      url: `/docs/${file}`,
+      body,
+    };
+  });
+  return _docsCache;
+}
+
+let _stepsCache = null;
+export function loadStepMetadata() {
+  if (_stepsCache) return _stepsCache;
+  // Run the pipeline once on a reference date to harvest step metadata
+  // (ids, names, Rambam refs, formulas, sourceNotes). The numeric results
+  // are date-specific and ignored here.
+  const ref = getFullCalculation(new Date('2024-01-01T00:00:00Z'));
+  _stepsCache = ref.steps.map((s) => ({
+    id: `step:${s.id}`,
+    stepId: s.id,
+    title: s.name + (s.hebrewName ? ` (${s.hebrewName})` : ''),
+    url: `/api/calculate?date=YYYY-MM-DD#${s.id}`,
+    body: [
+      s.name,
+      s.hebrewName,
+      s.rambamRef && `Rambam: ${s.rambamRef}`,
+      s.formula && `Formula: ${s.formula}`,
+      s.sourceNote,
+      s.teachingNote,
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  }));
+  return _stepsCache;
+}
+
+export function searchCorpus(query) {
+  const q = (query || '').trim().toLowerCase();
+  if (!q) return [];
+  const terms = q.split(/\s+/).filter(Boolean);
+  const items = [...loadDocs(), ...loadStepMetadata()];
+  const scored = [];
+  for (const item of items) {
+    const hay = (item.title + '\n' + item.body).toLowerCase();
+    let score = 0;
+    for (const t of terms) {
+      let idx = 0;
+      while ((idx = hay.indexOf(t, idx)) !== -1) {
+        score += hay.slice(Math.max(0, idx - 1), idx).match(/\W|^/) ? 2 : 1;
+        idx += t.length;
+      }
+    }
+    if (score > 0) {
+      // Build a snippet around the first match
+      const firstIdx = hay.indexOf(terms[0]);
+      const start = Math.max(0, firstIdx - 80);
+      const snippet = (item.body || '')
+        .slice(start, start + 240)
+        .replace(/\s+/g, ' ')
+        .trim();
+      scored.push({
+        id: item.id,
+        title: item.title,
+        url: item.url,
+        snippet,
+        score,
+      });
+    }
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, 20);
+}
+
+export function fetchById(id) {
+  if (!id) return null;
+  if (id.startsWith('doc:')) {
+    const doc = loadDocs().find((d) => d.id === id);
+    return doc ? { id: doc.id, title: doc.title, url: doc.url, content: doc.body } : null;
+  }
+  if (id.startsWith('step:')) {
+    const step = loadStepMetadata().find((s) => s.id === id);
+    return step ? { id: step.id, title: step.title, url: step.url, content: step.body } : null;
+  }
+  return null;
+}
+
+export function runCalculation(dateStr) {
+  if (!dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+    throw new Error('date must be YYYY-MM-DD (Gregorian)');
+  }
+  const d = new Date(dateStr + 'T12:00:00Z');
+  if (Number.isNaN(d.getTime())) throw new Error('invalid date');
+  const calc = getFullCalculation(d);
+  // Strip circular stepMap for JSON safety
+  return {
+    date: dateStr,
+    daysFromEpoch: calc.daysFromEpoch,
+    sun: calc.sun,
+    moon: calc.moon,
+    season: calc.season,
+    steps: calc.steps.map((s) => ({
+      id: s.id,
+      name: s.name,
+      hebrewName: s.hebrewName,
+      rambamRef: s.rambamRef,
+      formula: s.formula,
+      result: s.result,
+      unit: s.unit,
+      sourceNote: s.sourceNote,
+    })),
+  };
+}
+
+export function json(status, body, extraHeaders = {}) {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'access-control-allow-origin': '*',
+      'access-control-allow-headers': 'content-type',
+      'access-control-allow-methods': 'GET, POST, OPTIONS',
+      ...extraHeaders,
+    },
+  });
+}

--- a/netlify/functions/calculate.mjs
+++ b/netlify/functions/calculate.mjs
@@ -1,0 +1,14 @@
+import { runCalculation, json } from './_lib.mjs';
+
+export default async (req) => {
+  const url = new URL(req.url);
+  const date = url.searchParams.get('date');
+  try {
+    const result = runCalculation(date);
+    return json(200, result);
+  } catch (e) {
+    return json(400, { error: e.message });
+  }
+};
+
+export const config = { path: '/api/calculate' };

--- a/netlify/functions/doc.mjs
+++ b/netlify/functions/doc.mjs
@@ -1,16 +1,28 @@
-import { loadDocs } from './_lib.mjs';
+// Serve docs/*.md as clean markdown at /docs/<file>.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const DOCS_DIR = path.resolve(process.cwd(), 'docs');
 
 export default async (req) => {
   const url = new URL(req.url);
   const name = url.pathname.replace(/^\/docs\//, '');
-  const doc = loadDocs().find((d) => d.file === name);
-  if (!doc) {
+  if (!name || name.includes('..') || name.includes('/')) {
     return new Response('Not found', { status: 404 });
   }
-  return new Response(doc.body, {
+  let body;
+  try {
+    body = readFileSync(path.join(DOCS_DIR, name), 'utf8');
+  } catch {
+    return new Response(`Not found: ${name}`, { status: 404 });
+  }
+  const ct = name.endsWith('.md')
+    ? 'text/markdown; charset=utf-8'
+    : 'text/plain; charset=utf-8';
+  return new Response(body, {
     status: 200,
     headers: {
-      'content-type': 'text/markdown; charset=utf-8',
+      'content-type': ct,
       'cache-control': 'public, max-age=300',
       'access-control-allow-origin': '*',
     },

--- a/netlify/functions/doc.mjs
+++ b/netlify/functions/doc.mjs
@@ -1,0 +1,20 @@
+import { loadDocs } from './_lib.mjs';
+
+export default async (req) => {
+  const url = new URL(req.url);
+  const name = url.pathname.replace(/^\/docs\//, '');
+  const doc = loadDocs().find((d) => d.file === name);
+  if (!doc) {
+    return new Response('Not found', { status: 404 });
+  }
+  return new Response(doc.body, {
+    status: 200,
+    headers: {
+      'content-type': 'text/markdown; charset=utf-8',
+      'cache-control': 'public, max-age=300',
+      'access-control-allow-origin': '*',
+    },
+  });
+};
+
+export const config = { path: '/docs/*' };

--- a/netlify/functions/engine.mjs
+++ b/netlify/functions/engine.mjs
@@ -1,0 +1,94 @@
+// Serve the Rambam calculation engine as live ES modules so AI-generated
+// artifacts (Claude Artifacts, ChatGPT canvases, standalone HTML pages) can
+// `import` it directly from a stable URL without bundling or copy-pasting.
+//
+//   import { getFullCalculation } from "https://<site>/engine/pipeline.js";
+//
+// This is the single source of truth — these files are the ACTUAL engine
+// used by the dashboard UI, bundled into the function via `included_files`
+// in netlify.toml. Edit `src/engine/*.js` in the repo and it ships here.
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const ENGINE_DIR = path.resolve(process.cwd(), 'src/engine');
+const ALLOWED = new Set([
+  'pipeline.js',
+  'sunCalculations.js',
+  'moonCalculations.js',
+  'visibilityCalculations.js',
+  'constants.js',
+  'dmsUtils.js',
+]);
+
+const BANNER = (file) => `/*
+ * Kiddush HaChodesh — live engine module: ${file}
+ * Source: https://github.com/rayistern/kidushhachodesh/blob/main/src/engine/${file}
+ * License: MIT. Free to import, fork, and remix.
+ *
+ * This file is served live from the canonical source. To use it from an
+ * artifact or standalone page:
+ *
+ *   import { getFullCalculation } from "/engine/pipeline.js";
+ *   const calc = getFullCalculation(new Date());
+ *
+ * See /llms.txt and /docs/BUILDING_WITH_THE_ENGINE.md for recipes.
+ */
+
+`;
+
+export default async (req) => {
+  const url = new URL(req.url);
+  const name = url.pathname.replace(/^\/engine\//, '');
+
+  // Index listing
+  if (!name || name === '' || name === 'index.json') {
+    return new Response(
+      JSON.stringify(
+        {
+          description:
+            "Rambam's Kiddush HaChodesh calculation engine, served as live ES modules.",
+          license: 'MIT',
+          import_example:
+            'import { getFullCalculation } from "/engine/pipeline.js"',
+          files: [...ALLOWED].map((f) => ({
+            name: f,
+            url: `/engine/${f}`,
+          })),
+          entrypoint: '/engine/pipeline.js',
+        },
+        null,
+        2
+      ),
+      {
+        status: 200,
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          'access-control-allow-origin': '*',
+        },
+      }
+    );
+  }
+
+  if (!ALLOWED.has(name)) {
+    return new Response(`Not found: ${name}`, { status: 404 });
+  }
+
+  let body;
+  try {
+    body = readFileSync(path.join(ENGINE_DIR, name), 'utf8');
+  } catch {
+    return new Response(`Not found: ${name}`, { status: 404 });
+  }
+
+  return new Response(BANNER(name) + body, {
+    status: 200,
+    headers: {
+      'content-type': 'application/javascript; charset=utf-8',
+      'cache-control': 'public, max-age=300',
+      'access-control-allow-origin': '*',
+    },
+  });
+};
+
+export const config = { path: ['/engine', '/engine/*'] };

--- a/netlify/functions/mcp.mjs
+++ b/netlify/functions/mcp.mjs
@@ -1,0 +1,174 @@
+// Minimal Model Context Protocol (MCP) server over Streamable HTTP.
+// Implements just enough JSON-RPC 2.0 for consumer MCP clients:
+//   initialize, tools/list, tools/call (search | fetch | calculate).
+// No auth, no SSE, no resources — read-only. Good enough for Claude / ChatGPT
+// connectors that want a simple "paste this URL" experience.
+
+import { searchCorpus, fetchById, runCalculation, json } from './_lib.mjs';
+
+const PROTOCOL_VERSION = '2024-11-05';
+const SERVER_INFO = {
+  name: 'kidush-hachodesh',
+  version: '0.1.0',
+};
+
+const TOOLS = [
+  {
+    name: 'search',
+    description:
+      "Full-text search over the Kiddush HaChodesh docs and the Rambam's calculation steps. Returns ranked results with id, title, snippet, and canonical URL. Use the returned id with the `fetch` tool to retrieve full content.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query (English or Hebrew transliteration).' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'fetch',
+    description:
+      'Fetch the full content of a document or calculation-step entry by id (as returned by `search`). Ids look like `doc:CALCULATIONS.md` or `step:sunMeanLongitude`.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Entry id from a prior search result.' },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'calculate',
+    description:
+      "Run the Rambam's full astronomical pipeline for a given Gregorian date and return every intermediate step (sun mean/true longitude, moon maslul, double elongation, latitude, elongation, phase, first visibility, seasonal info). Use this instead of guessing any numeric values. Dates before the epoch (1177-04-03) are not meaningful.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        date: { type: 'string', description: 'Gregorian date as YYYY-MM-DD.' },
+      },
+      required: ['date'],
+    },
+  },
+];
+
+function rpcResult(id, result) {
+  return { jsonrpc: '2.0', id, result };
+}
+function rpcError(id, code, message) {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+function textContent(obj) {
+  const text = typeof obj === 'string' ? obj : JSON.stringify(obj, null, 2);
+  return { content: [{ type: 'text', text }] };
+}
+
+async function handleRpc(msg) {
+  const { id, method, params } = msg || {};
+  try {
+    switch (method) {
+      case 'initialize':
+        return rpcResult(id, {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: SERVER_INFO,
+          instructions:
+            "This server exposes the Rambam's Kiddush HaChodesh calculations. Use `search` to find docs or calculation steps, `fetch` to read them, and `calculate` to run the full astronomical pipeline for any Gregorian date. Never guess numeric values — call `calculate`.",
+        });
+
+      case 'notifications/initialized':
+      case 'initialized':
+        return null; // notification, no response
+
+      case 'tools/list':
+        return rpcResult(id, { tools: TOOLS });
+
+      case 'tools/call': {
+        const name = params?.name;
+        const args = params?.arguments || {};
+        if (name === 'search') {
+          const results = searchCorpus(args.query || '');
+          return rpcResult(id, textContent({ query: args.query, count: results.length, results }));
+        }
+        if (name === 'fetch') {
+          const entry = fetchById(args.id);
+          if (!entry) return rpcResult(id, { ...textContent(`Not found: ${args.id}`), isError: true });
+          return rpcResult(id, textContent(entry));
+        }
+        if (name === 'calculate') {
+          try {
+            const result = runCalculation(args.date);
+            return rpcResult(id, textContent(result));
+          } catch (e) {
+            return rpcResult(id, { ...textContent(`Error: ${e.message}`), isError: true });
+          }
+        }
+        return rpcError(id, -32601, `Unknown tool: ${name}`);
+      }
+
+      case 'ping':
+        return rpcResult(id, {});
+
+      default:
+        return rpcError(id, -32601, `Method not found: ${method}`);
+    }
+  } catch (e) {
+    return rpcError(id, -32603, `Internal error: ${e.message}`);
+  }
+}
+
+export default async (req) => {
+  const url = new URL(req.url);
+
+  // CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'access-control-allow-origin': '*',
+        'access-control-allow-methods': 'GET, POST, OPTIONS',
+        'access-control-allow-headers': 'content-type, mcp-session-id',
+      },
+    });
+  }
+
+  // GET on /mcp or /.well-known/mcp → human/agent-readable descriptor.
+  if (req.method === 'GET') {
+    return json(200, {
+      server: SERVER_INFO,
+      protocol: 'mcp',
+      protocolVersion: PROTOCOL_VERSION,
+      transport: 'streamable-http',
+      endpoint: '/mcp',
+      tools: TOOLS.map((t) => ({ name: t.name, description: t.description })),
+      note: 'POST JSON-RPC 2.0 messages to this URL. See /llms.txt for a full site map.',
+    });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return json(400, { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } });
+  }
+
+  // Support batched requests
+  if (Array.isArray(body)) {
+    const out = [];
+    for (const msg of body) {
+      const resp = await handleRpc(msg);
+      if (resp) out.push(resp);
+    }
+    return json(200, out);
+  }
+
+  const resp = await handleRpc(body);
+  if (resp === null) return new Response(null, { status: 202 });
+  return json(200, resp);
+};
+
+export const config = { path: ['/mcp', '/.well-known/mcp'] };

--- a/netlify/functions/mcp.mjs
+++ b/netlify/functions/mcp.mjs
@@ -1,26 +1,68 @@
-// Minimal Model Context Protocol (MCP) server over Streamable HTTP.
-// Implements just enough JSON-RPC 2.0 for consumer MCP clients:
-//   initialize, tools/list, tools/call (search | fetch | calculate).
-// No auth, no SSE, no resources — read-only. Good enough for Claude / ChatGPT
-// connectors that want a simple "paste this URL" experience.
+// Model Context Protocol server for Kiddush HaChodesh.
+//
+// Minimal Streamable-HTTP MCP implementation — just enough JSON-RPC 2.0 for
+// Claude Desktop, claude.ai connectors, ChatGPT developer-mode connectors,
+// and Cursor. No auth, no SSE — read-only.
+//
+// Tools exposed:
+//   search            — full-text search across the unified corpus (docs,
+//                       class transcripts, calculation steps, galgalim,
+//                       Rambam chapters, concepts, source categories).
+//   fetch             — fetch a single entry by id.
+//   calculate         — run the Rambam pipeline for a Gregorian date.
+//   list_templates    — list AI-artifact starter templates.
+//   get_template      — fetch one template verbatim.
+//   list_source       — list whitelisted source files (engine, docs).
+//   get_source        — fetch one source file verbatim.
+//   stats             — corpus stats (what's indexed, how many of each).
+//
+// See /llms.txt for the full site map and /docs/BUILDING_WITH_THE_ENGINE.md
+// for artifact-generation recipes.
 
-import { searchCorpus, fetchById, runCalculation, json } from './_lib.mjs';
+import {
+  searchCorpus,
+  fetchById,
+  runCalculation,
+  listSource,
+  getSource,
+  listTemplates,
+  getTemplate,
+  corpusStats,
+  json,
+} from './_lib.mjs';
 
 const PROTOCOL_VERSION = '2024-11-05';
-const SERVER_INFO = {
-  name: 'kidush-hachodesh',
-  version: '0.1.0',
-};
+const SERVER_INFO = { name: 'kidush-hachodesh', version: '0.2.0' };
+
+const INSTRUCTIONS = `This server exposes the Rambam's Kiddush HaChodesh calculations
+and teaching content (including class transcripts by Rabbi Zajac, hosted via
+Chabad.org). Use \`search\` to find content across docs, class transcripts,
+calculation steps, galgalim, Rambam chapters, and concept pages. Use \`fetch\`
+to read a full entry. Use \`calculate\` to run the full astronomical pipeline
+for any Gregorian date — never guess numeric values.
+
+When the user asks you to BUILD something (a standalone page, a script, a
+chart, a notebook), call \`list_templates\` then \`get_template\`, modify
+the template for the request, and hand the result to the user as an artifact.
+The engine is served live at /engine/pipeline.js so the artifact works with
+no build step. Use \`list_source\`/\`get_source\` to read the engine itself.
+
+Credit Rabbi Zajac and link to Chabad.org (https://www.chabad.org) when
+quoting class transcript content. The project is MIT-licensed — fork freely.`;
 
 const TOOLS = [
   {
     name: 'search',
     description:
-      "Full-text search over the Kiddush HaChodesh docs and the Rambam's calculation steps. Returns ranked results with id, title, snippet, and canonical URL. Use the returned id with the `fetch` tool to retrieve full content.",
+      'Full-text search across the unified Kiddush HaChodesh corpus: docs, class transcripts (Rabbi Zajac), calculation steps (21 Rambam steps with teaching notes), galgalim, Rambam chapters (KH 11-19), concept pages, and source-provenance categories. Returns ranked {id, type, title, rambamRef, url, snippet}. Follow up with `fetch` to read the full entry. Optional `type` filter narrows results to one category.',
     inputSchema: {
       type: 'object',
       properties: {
         query: { type: 'string', description: 'Search query (English or Hebrew transliteration).' },
+        type: {
+          type: 'string',
+          description: 'Optional type filter: doc | class | step | galgal | chapter | concept | source_type',
+        },
       },
       required: ['query'],
     },
@@ -28,19 +70,17 @@ const TOOLS = [
   {
     name: 'fetch',
     description:
-      'Fetch the full content of a document or calculation-step entry by id (as returned by `search`). Ids look like `doc:CALCULATIONS.md` or `step:sunMeanLongitude`.',
+      'Fetch the full content of one corpus entry by id (as returned by `search`). Ids are namespaced, e.g. `step:sunMaslul`, `galgal:moon`, `class:class2a`, `doc:CALCULATIONS.md`, `concept:emtzoi-vs-amiti`, `chapter:14`.',
     inputSchema: {
       type: 'object',
-      properties: {
-        id: { type: 'string', description: 'Entry id from a prior search result.' },
-      },
+      properties: { id: { type: 'string' } },
       required: ['id'],
     },
   },
   {
     name: 'calculate',
     description:
-      "Run the Rambam's full astronomical pipeline for a given Gregorian date and return every intermediate step (sun mean/true longitude, moon maslul, double elongation, latitude, elongation, phase, first visibility, seasonal info). Use this instead of guessing any numeric values. Dates before the epoch (1177-04-03) are not meaningful.",
+      "Run the Rambam's full astronomical pipeline for a Gregorian date. Returns every intermediate step (sun mean/true longitude, apogee, maslul, moon maslul, double elongation, maslul hanachon, latitude, node, elongation, phase, first visibility, seasonal info) with its Rambam chapter reference and teaching note. Use this instead of guessing any numeric values.",
     inputSchema: {
       type: 'object',
       properties: {
@@ -49,20 +89,68 @@ const TOOLS = [
       required: ['date'],
     },
   },
+  {
+    name: 'list_templates',
+    description:
+      'List starter templates for generating AI artifacts (standalone HTML calculators, Node CLIs, notebooks, etc.) that import the live engine. Follow up with `get_template` to read one, then modify for the user.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'get_template',
+    description:
+      'Fetch a starter template verbatim. The returned text is ready to modify and hand the user as an artifact. All templates import the engine from /engine/pipeline.js — keep that URL pointed at the live site unless the user asks otherwise.',
+    inputSchema: {
+      type: 'object',
+      properties: { name: { type: 'string', description: 'Template filename, e.g. "standalone-calculator.html".' } },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'list_source',
+    description:
+      'List whitelisted source areas and files (the calculation engine and the docs). Use this to discover the module map before reading individual files with `get_source`. Each file also has a stable live URL under /engine/ or /docs/ and a GitHub URL for forking.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        area: { type: 'string', description: 'Optional: "engine" | "docs". Omit for a list of areas.' },
+      },
+    },
+  },
+  {
+    name: 'get_source',
+    description:
+      'Fetch the full text of one source file (engine module or doc). Use this when you need to read the actual implementation to explain it, cite it, or adapt it into an artifact the user wants. The project is MIT-licensed — quoting and forking are explicitly allowed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        area: { type: 'string', description: '"engine" or "docs"' },
+        file: { type: 'string', description: 'Filename within the area.' },
+      },
+      required: ['area', 'file'],
+    },
+  },
+  {
+    name: 'stats',
+    description: 'Return corpus statistics — total entries and counts per type. Useful for sanity-checking what is indexed.',
+    inputSchema: { type: 'object', properties: {} },
+  },
 ];
 
+// ─── JSON-RPC helpers ─────────────────────────────────────────
 function rpcResult(id, result) {
   return { jsonrpc: '2.0', id, result };
 }
 function rpcError(id, code, message) {
   return { jsonrpc: '2.0', id, error: { code, message } };
 }
-
-function textContent(obj) {
+function textContent(obj, isError = false) {
   const text = typeof obj === 'string' ? obj : JSON.stringify(obj, null, 2);
-  return { content: [{ type: 'text', text }] };
+  const out = { content: [{ type: 'text', text }] };
+  if (isError) out.isError = true;
+  return out;
 }
 
+// ─── Dispatch one RPC message ─────────────────────────────────
 async function handleRpc(msg) {
   const { id, method, params } = msg || {};
   try {
@@ -72,8 +160,7 @@ async function handleRpc(msg) {
           protocolVersion: PROTOCOL_VERSION,
           capabilities: { tools: {} },
           serverInfo: SERVER_INFO,
-          instructions:
-            "This server exposes the Rambam's Kiddush HaChodesh calculations. Use `search` to find docs or calculation steps, `fetch` to read them, and `calculate` to run the full astronomical pipeline for any Gregorian date. Never guess numeric values — call `calculate`.",
+          instructions: INSTRUCTIONS,
         });
 
       case 'notifications/initialized':
@@ -83,28 +170,8 @@ async function handleRpc(msg) {
       case 'tools/list':
         return rpcResult(id, { tools: TOOLS });
 
-      case 'tools/call': {
-        const name = params?.name;
-        const args = params?.arguments || {};
-        if (name === 'search') {
-          const results = searchCorpus(args.query || '');
-          return rpcResult(id, textContent({ query: args.query, count: results.length, results }));
-        }
-        if (name === 'fetch') {
-          const entry = fetchById(args.id);
-          if (!entry) return rpcResult(id, { ...textContent(`Not found: ${args.id}`), isError: true });
-          return rpcResult(id, textContent(entry));
-        }
-        if (name === 'calculate') {
-          try {
-            const result = runCalculation(args.date);
-            return rpcResult(id, textContent(result));
-          } catch (e) {
-            return rpcResult(id, { ...textContent(`Error: ${e.message}`), isError: true });
-          }
-        }
-        return rpcError(id, -32601, `Unknown tool: ${name}`);
-      }
+      case 'tools/call':
+        return rpcResult(id, await callTool(params?.name, params?.arguments || {}));
 
       case 'ping':
         return rpcResult(id, {});
@@ -117,10 +184,51 @@ async function handleRpc(msg) {
   }
 }
 
-export default async (req) => {
-  const url = new URL(req.url);
+// ─── Tool dispatch ────────────────────────────────────────────
+async function callTool(name, args) {
+  switch (name) {
+    case 'search': {
+      const results = searchCorpus(args.query || '', { type: args.type });
+      return textContent({ query: args.query, type: args.type, count: results.length, results });
+    }
+    case 'fetch': {
+      const entry = fetchById(args.id);
+      if (!entry) return textContent(`Not found: ${args.id}`, true);
+      return textContent(entry);
+    }
+    case 'calculate': {
+      try {
+        return textContent(runCalculation(args.date));
+      } catch (e) {
+        return textContent(`Error: ${e.message}`, true);
+      }
+    }
+    case 'list_templates':
+      return textContent({ templates: listTemplates() });
+    case 'get_template': {
+      const body = getTemplate(args.name);
+      if (body == null) return textContent(`Not found: ${args.name}`, true);
+      return textContent(body);
+    }
+    case 'list_source': {
+      const listing = listSource(args.area);
+      if (!listing) return textContent(`Unknown area: ${args.area}`, true);
+      return textContent(listing);
+    }
+    case 'get_source': {
+      const src = getSource(args.area, args.file);
+      if (!src) return textContent(`Not found: ${args.area}/${args.file}`, true);
+      return textContent(src);
+    }
+    case 'stats':
+      return textContent(corpusStats());
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
 
-  // CORS preflight
+// ─── HTTP handler ─────────────────────────────────────────────
+export default async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, {
       status: 204,
@@ -132,7 +240,7 @@ export default async (req) => {
     });
   }
 
-  // GET on /mcp or /.well-known/mcp → human/agent-readable descriptor.
+  // GET → human/agent-readable descriptor
   if (req.method === 'GET') {
     return json(200, {
       server: SERVER_INFO,
@@ -141,7 +249,8 @@ export default async (req) => {
       transport: 'streamable-http',
       endpoint: '/mcp',
       tools: TOOLS.map((t) => ({ name: t.name, description: t.description })),
-      note: 'POST JSON-RPC 2.0 messages to this URL. See /llms.txt for a full site map.',
+      stats: corpusStats(),
+      note: 'POST JSON-RPC 2.0 messages to this URL. See /llms.txt for the full site map.',
     });
   }
 
@@ -156,7 +265,6 @@ export default async (req) => {
     return json(400, { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } });
   }
 
-  // Support batched requests
   if (Array.isArray(body)) {
     const out = [];
     for (const msg of body) {

--- a/netlify/functions/search.mjs
+++ b/netlify/functions/search.mjs
@@ -1,0 +1,10 @@
+import { searchCorpus, json } from './_lib.mjs';
+
+export default async (req) => {
+  const url = new URL(req.url);
+  const q = url.searchParams.get('q') || '';
+  const results = searchCorpus(q);
+  return json(200, { query: q, count: results.length, results });
+};
+
+export const config = { path: '/api/search' };

--- a/netlify/functions/source.mjs
+++ b/netlify/functions/source.mjs
@@ -1,0 +1,34 @@
+// Browseable read-only source endpoint. Complements /engine/* (which serves
+// the engine files with a JS content-type for live imports) by returning
+// source for any whitelisted area (engine, docs) as plain text for AI
+// assistants that want to read and cite code.
+
+import { listSource, getSource, json } from './_lib.mjs';
+
+export default async (req) => {
+  const url = new URL(req.url);
+  const area = url.searchParams.get('area');
+  const file = url.searchParams.get('file');
+
+  if (!area) return json(200, listSource());
+
+  if (!file) {
+    const listing = listSource(area);
+    if (!listing) return json(404, { error: `unknown area: ${area}` });
+    return json(200, listing);
+  }
+
+  const src = getSource(area, file);
+  if (!src) return json(404, { error: `not found: ${area}/${file}` });
+
+  return new Response(src.content, {
+    status: 200,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'public, max-age=300',
+      'access-control-allow-origin': '*',
+    },
+  });
+};
+
+export const config = { path: '/api/source' };

--- a/netlify/functions/templates.mjs
+++ b/netlify/functions/templates.mjs
@@ -1,0 +1,77 @@
+// Serve starter templates so AI assistants can fetch them as a scaffold for
+// generating artifacts on the user's behalf. All templates are plain text/html
+// files under `templates/` in the repo, bundled into the function via
+// `included_files` in netlify.toml.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const TEMPLATES_DIR = path.resolve(process.cwd(), 'templates');
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.md': 'text/markdown; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+function listTemplates() {
+  return readdirSync(TEMPLATES_DIR)
+    .filter((f) => !f.startsWith('.') && f !== 'README.md')
+    .map((f) => ({
+      name: f,
+      url: `/templates/${f}`,
+      kind: path.extname(f).slice(1),
+    }));
+}
+
+export default async (req) => {
+  const url = new URL(req.url);
+  const name = url.pathname.replace(/^\/templates\/?/, '');
+
+  // Index listing
+  if (!name || name === '') {
+    const body = {
+      description:
+        'Starter templates that AI assistants can fetch, modify, and hand the user as a working artifact. All import the live engine from /engine/pipeline.js.',
+      license: 'MIT',
+      templates: listTemplates(),
+      readme_url: '/templates/README.md',
+      engine_url: '/engine/pipeline.js',
+      building_guide_url: '/docs/BUILDING_WITH_THE_ENGINE.md',
+    };
+    return new Response(JSON.stringify(body, null, 2), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'access-control-allow-origin': '*',
+      },
+    });
+  }
+
+  // Path traversal guard
+  if (name.includes('..') || name.includes('/')) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  let body;
+  try {
+    body = readFileSync(path.join(TEMPLATES_DIR, name), 'utf8');
+  } catch {
+    return new Response(`Not found: ${name}`, { status: 404 });
+  }
+
+  const ext = path.extname(name).toLowerCase();
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'content-type': MIME[ext] || 'text/plain; charset=utf-8',
+      'cache-control': 'public, max-age=300',
+      'access-control-allow-origin': '*',
+    },
+  });
+};
+
+export const config = { path: ['/templates', '/templates/*'] };

--- a/public/agents.md
+++ b/public/agents.md
@@ -1,0 +1,36 @@
+# For AI assistants & their users
+
+This site exposes the Rambam's Kiddush HaChodesh calculations in a machine-
+navigable way, so you can point any AI chat (Claude, ChatGPT, Perplexity, etc.)
+at it and have a conversation about the underlying astronomy and halacha
+without having to pre-load everything into context.
+
+## How to use it
+
+**If your AI supports MCP (Claude Desktop, claude.ai connectors, ChatGPT
+developer-mode connectors, Cursor, etc.):** add this URL as an MCP server:
+
+    https://<this-site>/mcp
+
+It exposes three tools: `search`, `fetch`, and `calculate`.
+
+**If your AI just browses the web (consumer ChatGPT with search, Claude with web
+search, Perplexity, Gemini, …):** tell it:
+
+> Browse <this-site> and read /llms.txt first — it is a map of the site written
+> for you. Then answer my question, calling /api/calculate?date=YYYY-MM-DD for
+> any specific date.
+
+Either way it is the same URL. The model picks the door.
+
+## What it knows
+
+- Every step of the Rambam's sun, moon, and visibility calculations.
+- The full set of constants (epoch, daily motions, table corrections).
+- Calculations for any Gregorian date via `/api/calculate?date=…`.
+- The docs in `/docs/*.md`.
+
+## What it does NOT do (yet)
+
+- No "use gallery" / submissions — that is phase 2 and will need a database.
+- No per-user auth. Everything here is read-only and public.

--- a/public/ai.html
+++ b/public/ai.html
@@ -1,0 +1,321 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Chat with Kiddush HaChodesh — AI access</title>
+    <meta
+      name="description"
+      content="Point Claude, ChatGPT, or any AI at this project. Search the Rambam's calculations, ask questions, and generate working artifacts from our live engine."
+    />
+    <style>
+      :root {
+        --fg: #1a1a1a;
+        --muted: #666;
+        --bg: #fafaf8;
+        --card: #fff;
+        --border: #e5e5e0;
+        --accent: #2b6cb0;
+        --accent-hover: #234e7e;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --fg: #f0eee8;
+          --muted: #a8a49c;
+          --bg: #14130f;
+          --card: #1e1c17;
+          --border: #2d2a23;
+          --accent: #60a5fa;
+          --accent-hover: #93c5fd;
+        }
+      }
+      * { box-sizing: border-box; }
+      body {
+        font: 16px/1.6 -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+        color: var(--fg);
+        background: var(--bg);
+        margin: 0;
+      }
+      main { max-width: 780px; margin: 0 auto; padding: 2rem 1.2rem 4rem; }
+      nav { font-size: 14px; margin-bottom: 2rem; }
+      nav a { color: var(--muted); text-decoration: none; }
+      nav a:hover { color: var(--accent); }
+      h1 { font-size: 2.2rem; margin: 0 0 0.3em; line-height: 1.15; }
+      .hebrew { font-family: 'David', 'Times New Roman', serif; direction: rtl; font-size: 1.8rem; color: var(--muted); display: block; margin-bottom: 0.4em; }
+      .lede { color: var(--muted); font-size: 1.1rem; margin-top: 0; }
+      h2 { margin-top: 2.5rem; font-size: 1.4rem; border-bottom: 1px solid var(--border); padding-bottom: 0.4rem; }
+      h3 { margin-top: 1.8rem; font-size: 1.1rem; }
+      .url-box {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 0.8rem 1rem;
+        font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+        font-size: 15px;
+        margin: 1rem 0;
+        word-break: break-all;
+      }
+      .url-box code { flex: 1; }
+      button.copy {
+        font: inherit;
+        font-size: 13px;
+        background: var(--accent);
+        color: white;
+        border: 0;
+        padding: 0.4rem 0.8rem;
+        border-radius: 6px;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      button.copy:hover { background: var(--accent-hover); }
+      .card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 1.2rem 1.4rem;
+        margin: 1.2rem 0;
+      }
+      .card h3 { margin-top: 0; }
+      ol, ul { padding-left: 1.3rem; }
+      li { margin: 0.4rem 0; }
+      code { background: var(--card); padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.92em; }
+      pre { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1rem; overflow-x: auto; font-size: 13px; }
+      .grid { display: grid; grid-template-columns: 1fr; gap: 1rem; margin: 1rem 0; }
+      @media (min-width: 640px) { .grid.two { grid-template-columns: 1fr 1fr; } }
+      .pill {
+        display: inline-block;
+        background: var(--accent);
+        color: white;
+        padding: 0.15em 0.6em;
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      a { color: var(--accent); }
+      a:hover { color: var(--accent-hover); }
+      footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--muted); font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <nav><a href="/">← Back to dashboard</a></nav>
+
+      <span class="hebrew">קידוש החודש</span>
+      <h1>Chat with this whole project</h1>
+      <p class="lede">
+        Point any AI (Claude, ChatGPT, Perplexity, Cursor…) at this site and
+        have a real conversation with the Rambam's calculations, the class
+        transcripts, and every concept in the system. The AI can even build
+        you working artifacts from our live calculation engine.
+      </p>
+
+      <h2>The URL</h2>
+      <p>One URL. Two doors. The AI picks the right one automatically.</p>
+      <div class="url-box">
+        <code id="site-url">https://kidushhachodesh.netlify.app</code>
+        <button class="copy" data-copy="site-url">Copy</button>
+      </div>
+
+      <div class="grid two">
+        <div class="card">
+          <span class="pill">Door 1</span>
+          <h3>MCP (recommended)</h3>
+          <p>
+            For Claude Desktop, claude.ai connectors, ChatGPT developer mode,
+            Cursor, etc. Add this as an MCP server:
+          </p>
+          <div class="url-box">
+            <code id="mcp-url">https://kidushhachodesh.netlify.app/mcp</code>
+            <button class="copy" data-copy="mcp-url">Copy</button>
+          </div>
+          <p>
+            The AI gets 8 tools: <code>search</code>, <code>fetch</code>,
+            <code>calculate</code>, <code>list_templates</code>,
+            <code>get_template</code>, <code>list_source</code>,
+            <code>get_source</code>, <code>stats</code>.
+          </p>
+        </div>
+
+        <div class="card">
+          <span class="pill">Door 2</span>
+          <h3>Web browsing</h3>
+          <p>
+            For consumer ChatGPT, Claude with web search, Perplexity, Gemini,
+            or anything that can fetch URLs. Just tell the AI:
+          </p>
+          <pre>Browse kidushhachodesh.netlify.app
+and read /llms.txt first — it is a
+map of the site written for you.
+Then answer my question.</pre>
+          <p>
+            No install, no setup. Works in every browsing-capable AI today.
+          </p>
+        </div>
+      </div>
+
+      <h2>What the AI can do</h2>
+      <ul>
+        <li>
+          <strong>Answer questions</strong> about the Rambam's astronomy,
+          the galgalim, emtzoi vs. amiti, maslul, nekudah hanichaches,
+          moon visibility, molad timing — citing the exact KH chapter.
+        </li>
+        <li>
+          <strong>Run calculations</strong> for any Gregorian date and walk
+          you through all 21 pipeline steps.
+        </li>
+        <li>
+          <strong>Pull from the class transcripts</strong> — Rabbi Zajac's
+          lectures on KH 12-16 are indexed and searchable.
+        </li>
+        <li>
+          <strong>Build you an artifact.</strong> Ask for "a standalone page
+          that shows me the next 30 days of moon visibility" or "a Node
+          script that dumps the maslul table" and the AI can generate it
+          using our live engine.
+        </li>
+        <li>
+          <strong>Fork and remix.</strong> The engine is served live at
+          <a href="/engine/pipeline.js"><code>/engine/pipeline.js</code></a>
+          so any generated artifact just <code>import</code>s it — no build
+          step, no copy-paste.
+        </li>
+      </ul>
+
+      <h2>Try it right now</h2>
+
+      <div class="card">
+        <h3>With Claude</h3>
+        <ol>
+          <li>Open Claude Desktop or claude.ai.</li>
+          <li>
+            In Settings → Connectors (or via Desktop config), add an MCP
+            server with URL <code>https://kidushhachodesh.netlify.app/mcp</code>.
+          </li>
+          <li>
+            Start a new chat and ask: <em>"When is the next time the new
+            moon is visible at sunset in Jerusalem? Use the Rambam's
+            calculations."</em>
+          </li>
+        </ol>
+      </div>
+
+      <div class="card">
+        <h3>With ChatGPT (browsing mode)</h3>
+        <ol>
+          <li>Open ChatGPT with web search enabled.</li>
+          <li>
+            Paste: <em>"Browse kidushhachodesh.netlify.app and read
+            /llms.txt. Then explain the difference between emtzoi and amiti
+            for the sun, with a specific example for today's date using
+            /api/calculate."</em>
+          </li>
+          <li>
+            The model will fetch the site map, then the concept page, then
+            call the calculate endpoint, then answer.
+          </li>
+        </ol>
+      </div>
+
+      <div class="card">
+        <h3>Build yourself an artifact</h3>
+        <p>
+          With either Claude or ChatGPT connected, try:
+        </p>
+        <pre>Build me a one-page calculator showing
+the moon's phase and visibility for every
+day of Nisan 5786. Use our live engine.</pre>
+        <p>
+          The AI will fetch <a href="/templates/standalone-calculator.html">
+          <code>/templates/standalone-calculator.html</code></a>, modify it
+          for your request, and hand it to you as a working artifact that
+          already imports our engine.
+        </p>
+      </div>
+
+      <h2>What it knows (content index)</h2>
+      <p>
+        Call <code>stats</code> via MCP or just visit
+        <a href="/mcp"><code>/mcp</code></a> in a browser for the live count.
+        Current corpus:
+      </p>
+      <ul>
+        <li><strong>6 docs</strong> — calculation spec, building guide, etc.</li>
+        <li><strong>2 class transcripts</strong> — Rabbi Zajac, via Chabad.org</li>
+        <li><strong>21 calculation steps</strong> — every step in the Rambam pipeline, with Hebrew names, KH refs, formulas, and teaching notes</li>
+        <li><strong>9 galgalim</strong> — celestial spheres with Rabbi Losh's pedagogical framing</li>
+        <li><strong>9 Rambam chapters</strong> — KH 11-19, linked to Sefaria</li>
+        <li><strong>4 concept pages</strong> — sun/moon galgalim, emtzoi vs. amiti, nekudah hanichaches</li>
+        <li><strong>4 source categories</strong> — provenance (Rambam / Interpolated / Deduced / Losh)</li>
+      </ul>
+
+      <h2>Under the hood</h2>
+      <ul>
+        <li>
+          Full site map for agents:
+          <a href="/llms.txt"><code>/llms.txt</code></a>
+        </li>
+        <li>
+          MCP descriptor:
+          <a href="/mcp"><code>/mcp</code></a> /
+          <a href="/.well-known/mcp"><code>/.well-known/mcp</code></a>
+        </li>
+        <li>
+          HTTP API: <code>/api/search</code>, <code>/api/calculate</code>,
+          <code>/api/source</code>
+        </li>
+        <li>
+          Live engine modules:
+          <a href="/engine/index.json"><code>/engine/</code></a>
+        </li>
+        <li>
+          Templates:
+          <a href="/templates/"><code>/templates/</code></a>
+        </li>
+        <li>
+          Building guide:
+          <a href="/docs/BUILDING_WITH_THE_ENGINE.md">
+            <code>/docs/BUILDING_WITH_THE_ENGINE.md</code>
+          </a>
+        </li>
+        <li>
+          Source:
+          <a href="https://github.com/rayistern/kidushhachodesh">
+            github.com/rayistern/kidushhachodesh
+          </a>
+          (MIT)
+        </li>
+      </ul>
+
+      <footer>
+        Class transcripts are teachings by Rabbi Zajac, hosted with permission.
+        Please credit Rabbi Zajac and link to
+        <a href="https://www.chabad.org">Chabad.org</a> when quoting from them.
+        Calculation engine implements the Rambam's Hilchot Kiddush HaChodesh,
+        chapters 11-19. MIT-licensed — fork, remix, and build freely.
+      </footer>
+    </main>
+
+    <script>
+      // Use the real origin at runtime so the copy buttons work on any deploy.
+      const origin = location.origin;
+      document.getElementById('site-url').textContent = origin;
+      document.getElementById('mcp-url').textContent = origin + '/mcp';
+      for (const btn of document.querySelectorAll('button.copy')) {
+        btn.addEventListener('click', () => {
+          const text = document.getElementById(btn.dataset.copy).textContent;
+          navigator.clipboard.writeText(text).then(() => {
+            const orig = btn.textContent;
+            btn.textContent = 'Copied!';
+            setTimeout(() => (btn.textContent = orig), 1200);
+          });
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,63 +1,150 @@
 # Kiddush HaChodesh
 
-> An interactive dashboard of the Rambam's astronomical calculations for sanctifying
-> the new month (Hilchot Kiddush HaChodesh, chapters 11-17), with a full calculation
-> engine, 3D visualizations, and an MCP-compatible API so AI assistants can chat
-> with the underlying model, run calculations for any date, and cite the sources.
+> An interactive study of the Rambam's astronomical calculations for sanctifying
+> the new month (Hilchot Kiddush HaChodesh, chapters 11-19), with a full live
+> calculation engine, Rabbi Zajac's class transcripts, and an MCP-compatible
+> API so AI assistants can chat with the underlying model, run calculations
+> for any date, cite the sources, and generate working artifacts.
 
-This file is for AI agents. A human-readable guide lives at /agents.md.
+This file is a map of the site written for AI agents. A human-readable version
+lives at `/agents.md`. The project is MIT-licensed and the repo is public at
+https://github.com/rayistern/kidushhachodesh.
 
-## How to navigate this site (for AI agents)
+Teaching content (class transcripts) is by Rabbi Zajac, hosted with permission.
+When you quote from class transcripts, credit Rabbi Zajac and link to Chabad.org
+(https://www.chabad.org).
 
-You have two ways to use this site:
+## Two doors, one URL
 
-1. **Browsing / web search.** Fetch the markdown URLs below. They are clean,
-   chrome-free, and stable. Always prefer the `.md` endpoints over the HTML site
-   when you just need the content.
+1. **MCP (preferred).** A JSON-RPC 2.0 Model Context Protocol server lives at
+   `/mcp` (descriptor at `/.well-known/mcp`). It exposes the tools listed
+   below. Point any MCP client (Claude Desktop, claude.ai connectors, ChatGPT
+   developer mode, Cursor, …) at `/mcp`.
 
-2. **MCP (Model Context Protocol).** A JSON-RPC 2.0 MCP endpoint lives at `/mcp`.
-   It exposes `search`, `fetch`, and `calculate` tools. If your client supports
-   MCP, point it at `/mcp` — it is faster and more deterministic than browsing.
-   Descriptor: `/.well-known/mcp`.
+2. **Plain web browsing.** If you don't speak MCP, fetch the `.md` URLs below.
+   They are clean, chrome-free, cache-friendly, and stable.
 
-Whichever mode you use, cite pages by their canonical URL.
+Both doors talk to the same corpus and the same engine. Pick whichever works.
 
-## Core documents
+## MCP tools
 
-- [Calculation engine overview](/docs/CALCULATIONS.md): every step in the Rambam's
-  procedure — sun, moon, visibility — with formulas and chapter refs.
-- [Astronomical model](/docs/ASTRONOMICAL_MODEL.md): the nested-galgalim model
-  (Rabbi Losh's teaching framing).
-- [Constants reference](/docs/CONSTANTS_REFERENCE.md): every constant used, with
-  its Rambam source.
-- [Development guide](/docs/DEVELOPMENT_GUIDE.md)
+- `search({query, type?})` — full-text search across the unified corpus. Types:
+  `doc`, `class`, `step`, `galgal`, `chapter`, `concept`, `source_type`.
+- `fetch({id})` — read one entry by namespaced id (e.g. `step:sunMaslul`,
+  `galgal:moon`, `class:class2a`, `concept:emtzoi-vs-amiti`, `chapter:14`,
+  `doc:CALCULATIONS.md`).
+- `calculate({date})` — run the full Rambam pipeline for a Gregorian date.
+  Returns every intermediate step with its `rambamRef` and teaching note.
+  **Always call this instead of guessing numeric values.**
+- `list_templates()` / `get_template({name})` — fetch AI-artifact scaffolds
+  (standalone HTML calculators, Node CLIs, …) that import the live engine.
+- `list_source({area?})` / `get_source({area, file})` — browse the engine
+  and docs source code. Area is `engine` or `docs`. MIT-licensed.
+- `stats()` — corpus counts by type.
 
-## Live calculation endpoint
+## HTTP endpoints (for browsing or non-MCP use)
 
-- `GET /api/calculate?date=YYYY-MM-DD` → JSON. Runs the full Rambam pipeline for
-  that civil date and returns every intermediate step (days from epoch, sun mean
-  longitude, apogee, maslul, corrections, true longitudes, moon maslul, double
-  elongation, maslul hanachon, node, latitude, elongation, phase, first
-  visibility, seasonal info). Each step includes its `rambamRef`, `formula`, and
-  `sourceNote`, so you can cite the Rambam directly.
+- `GET /api/search?q=…[&type=…]` — JSON search results.
+- `GET /api/calculate?date=YYYY-MM-DD` — JSON pipeline output.
+- `GET /api/source?area=engine` / `…&file=pipeline.js` — source browsing.
+- `GET /docs/<file>.md` — clean markdown of any doc.
+- `GET /engine/<module>.js` — live ES module (importable from any artifact).
+- `GET /engine/index.json` — engine module map.
+- `GET /templates/` — template index.
+- `GET /templates/<name>` — one template verbatim.
 
-## Search
+## Content categories (what `search` indexes)
 
-- `GET /api/search?q=<query>` → JSON. Searches the docs and every calculation
-  step description. Returns `{results: [{id, title, snippet, url}]}`.
+1. **docs** — hand-written reference docs in `/docs/`. Finished:
+   `CALCULATIONS.md` (full calculation spec with tables and teaching notes)
+   and `BUILDING_WITH_THE_ENGINE.md` (recipes for forking and artifact
+   generation). Stubs: `ASTRONOMICAL_MODEL.md`, `CONSTANTS_REFERENCE.md`,
+   `DEVELOPMENT_GUIDE.md`.
+
+2. **class** — raw transcripts of Rabbi Zajac's Rambam classes. Two classes
+   currently indexed:
+   - `class:class1a` — KH 12-13, the sun model (galgalim, emtzoi/amiti,
+     govah, maslul, airplane + translation mashalim).
+   - `class:class2a` — KH 14-16, the moon model (four galgalim, season
+     correction, double elongation, nekudah hanichaches, rosh/zanav, latitude).
+   Credit Rabbi Zajac via Chabad.org when quoting.
+
+3. **step** — 21 calculation steps from the Rambam pipeline. Each carries
+   Hebrew name, `rambamRef`, formula, source note, and (for 15 of them) a
+   rich teaching note in the Rabbi Losh tradition. Covers the full chain
+   from `daysFromEpoch` through `moonVisibility`.
+
+4. **galgal** — 9 galgalim (celestial spheres) from
+   `src/engine/constants.js`: the daily sphere, sphere of constellations,
+   five planet spheres, sun sphere, and moon sphere. Sun and moon galgalim
+   carry Rabbi Losh's pedagogical color scheme and teaching note.
+
+5. **chapter** — the 9 Rambam chapters of Hilchot Kiddush HaChodesh (11-19),
+   with English + Hebrew titles. Full text is live from Sefaria.org.
+
+6. **concept** — hand-curated concept pages covering the most-asked ideas:
+   sun galgalim system, moon four-galgalim system, emtzoi vs. amiti,
+   nekudah hanichaches. Built from prose originally in the dashboard's
+   KnowledgeBase component.
+
+7. **source_type** — the provenance legend: Rambam [R], Interpolated [~],
+   Deduced [D], Rabbi Losh [L]. Use this to honestly label claims.
+
+## Building artifacts (fork + remix)
+
+The calculation engine is served live at `/engine/pipeline.js`. Any artifact
+(Claude Artifact, ChatGPT canvas, standalone HTML, Node script, observable
+notebook) can `import` it directly:
+
+    import { getFullCalculation } from "/engine/pipeline.js";
+    const calc = getFullCalculation(new Date("2026-04-07"));
+
+No build step, no install, no copy-paste. Start from a template:
+
+- `/templates/standalone-calculator.html` — one-file browser calculator.
+- `/templates/node-cli.mjs` — Node 18+ command-line tool.
+
+Full recipes live in `/docs/BUILDING_WITH_THE_ENGINE.md`. To fork the project,
+clone https://github.com/rayistern/kidushhachodesh and see the repo README.
 
 ## Tips for answering user questions
 
-- For "when is molad / is the moon visible on <date>" type questions, call
-  `/api/calculate?date=...` first; do not guess.
-- For "what is the maslul / why does the Rambam do X" type questions, fetch
-  `/docs/CALCULATIONS.md` and cite the specific `KH` chapter reference.
-- Hebrew dates: the engine expects a civil (Gregorian) date. Convert first.
-- The epoch is 3 Nisan 4938 = 1177-04-03.
-- Do not invent calculation values; always call `/api/calculate`.
+- For "when is molad / is the moon visible / what is the maslul on <date>"
+  questions, **call `calculate` first**, then explain using the step metadata
+  it returns. Never fabricate numeric values.
+- For "what is X / why does the Rambam do X" questions, `search` the corpus
+  (narrowing with `type: "concept"` or `type: "step"` often helps), then
+  `fetch` the best match and cite its `rambamRef`.
+- Hebrew dates: convert to Gregorian before calling `calculate`. The epoch
+  is 3 Nisan 4938 = 1177-04-03.
+- When a user asks for a visual or interactive artifact, use
+  `list_templates` + `get_template` and modify for their request. Keep
+  the `/engine/pipeline.js` import URL pointed at the live site so the
+  artifact works out of the box.
+- Honest provenance: use the `source_type` categories. Don't claim something
+  is "from the Rambam" if it's actually `deduced` or `losh`.
 
-## MCP tools (if using /mcp)
+## Taxonomy quick reference
 
-- `search({query})` — same as `/api/search`.
-- `fetch({id})` — fetch a doc page or a calculation step by id.
-- `calculate({date})` — run the full pipeline for a Gregorian date (YYYY-MM-DD).
+| Type | Count (approx) | Id prefix | Typical source |
+|---|---|---|---|
+| doc | 5 | `doc:` | `docs/*.md` |
+| class | 2 | `class:` | `docs/class*.txt` (Zajac) |
+| step | 21 | `step:` | `src/engine/*.js` |
+| galgal | 9 | `galgal:` | `src/engine/constants.js` |
+| chapter | 9 | `chapter:` | Sefaria (live) |
+| concept | 4+ | `concept:` | KnowledgeBase.jsx + curated |
+| source_type | 4 | `source_type:` | `SOURCE_TYPES` enum |
+
+Call `stats()` for the live count.
+
+## Gaps (things the user should know about)
+
+- `ASTRONOMICAL_MODEL.md`, `CONSTANTS_REFERENCE.md`, `DEVELOPMENT_GUIDE.md`
+  are stubs — the content is elsewhere in the corpus (mainly
+  `CALCULATIONS.md` and the engine teaching notes).
+- Class transcripts are raw audio — stream-of-consciousness, with Yiddish
+  and English mixed. Quote cautiously.
+- `RambamReader` pulls full KH chapter text live from Sefaria.org; if
+  Sefaria is down, chapter body text won't load (the chapter entries in
+  the corpus still have titles and rambamRef).

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,63 @@
+# Kiddush HaChodesh
+
+> An interactive dashboard of the Rambam's astronomical calculations for sanctifying
+> the new month (Hilchot Kiddush HaChodesh, chapters 11-17), with a full calculation
+> engine, 3D visualizations, and an MCP-compatible API so AI assistants can chat
+> with the underlying model, run calculations for any date, and cite the sources.
+
+This file is for AI agents. A human-readable guide lives at /agents.md.
+
+## How to navigate this site (for AI agents)
+
+You have two ways to use this site:
+
+1. **Browsing / web search.** Fetch the markdown URLs below. They are clean,
+   chrome-free, and stable. Always prefer the `.md` endpoints over the HTML site
+   when you just need the content.
+
+2. **MCP (Model Context Protocol).** A JSON-RPC 2.0 MCP endpoint lives at `/mcp`.
+   It exposes `search`, `fetch`, and `calculate` tools. If your client supports
+   MCP, point it at `/mcp` — it is faster and more deterministic than browsing.
+   Descriptor: `/.well-known/mcp`.
+
+Whichever mode you use, cite pages by their canonical URL.
+
+## Core documents
+
+- [Calculation engine overview](/docs/CALCULATIONS.md): every step in the Rambam's
+  procedure — sun, moon, visibility — with formulas and chapter refs.
+- [Astronomical model](/docs/ASTRONOMICAL_MODEL.md): the nested-galgalim model
+  (Rabbi Losh's teaching framing).
+- [Constants reference](/docs/CONSTANTS_REFERENCE.md): every constant used, with
+  its Rambam source.
+- [Development guide](/docs/DEVELOPMENT_GUIDE.md)
+
+## Live calculation endpoint
+
+- `GET /api/calculate?date=YYYY-MM-DD` → JSON. Runs the full Rambam pipeline for
+  that civil date and returns every intermediate step (days from epoch, sun mean
+  longitude, apogee, maslul, corrections, true longitudes, moon maslul, double
+  elongation, maslul hanachon, node, latitude, elongation, phase, first
+  visibility, seasonal info). Each step includes its `rambamRef`, `formula`, and
+  `sourceNote`, so you can cite the Rambam directly.
+
+## Search
+
+- `GET /api/search?q=<query>` → JSON. Searches the docs and every calculation
+  step description. Returns `{results: [{id, title, snippet, url}]}`.
+
+## Tips for answering user questions
+
+- For "when is molad / is the moon visible on <date>" type questions, call
+  `/api/calculate?date=...` first; do not guess.
+- For "what is the maslul / why does the Rambam do X" type questions, fetch
+  `/docs/CALCULATIONS.md` and cite the specific `KH` chapter reference.
+- Hebrew dates: the engine expects a civil (Gregorian) date. Convert first.
+- The epoch is 3 Nisan 4938 = 1177-04-03.
+- Do not invent calculation values; always call `/api/calculate`.
+
+## MCP tools (if using /mcp)
+
+- `search({query})` — same as `/api/search`.
+- `fetch({id})` — fetch a doc page or a calculation step by id.
+- `calculate({date})` — run the full pipeline for a Gregorian date (YYYY-MM-DD).

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -75,6 +75,14 @@ export default function AppShell() {
           <NavButton icon="🔭" label="Explore" />
           <NavButton icon="🧮" label="Calculate" />
           <NavButton icon="📖" label="Learn" />
+          <a
+            href="/ai.html"
+            className="tap-target px-2 sm:px-3 rounded-lg text-xs sm:text-sm font-medium text-white bg-[var(--color-accent,#2b6cb0)] hover:opacity-90 transition-opacity flex items-center"
+            title="Chat with this whole project using Claude, ChatGPT, or any AI. Build artifacts from our engine."
+          >
+            <span className="text-base sm:text-sm">✨</span>
+            <span className="hidden sm:inline ml-1">Chat with AI</span>
+          </a>
           <PanelToggle
             onClick={toggleRightPanel}
             active={rightPanelOpen}

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,29 @@
+# Starter templates
+
+Small, copy-pasteable scaffolds that use the Kiddush HaChodesh calculation
+engine. Designed for AI assistants (Claude, ChatGPT) to fetch, modify, and
+hand the user as a working artifact — but humans can use them directly too.
+
+All templates import the engine **live** from the project's deployment, so
+there is no build step and no install. If you want to self-host, change the
+base URL at the top of each file.
+
+## Templates
+
+| File | What it is |
+|---|---|
+| [`standalone-calculator.html`](./standalone-calculator.html) | Single HTML file. Date picker + full pipeline output. Drop into any browser or paste into a Claude Artifact. |
+| [`node-cli.mjs`](./node-cli.mjs) | Node 18+ CLI. `node node-cli.mjs 2026-04-07`. Uses dynamic `import()` from the live engine. |
+
+## How an AI should use these
+
+1. Fetch the template you want via `/templates/<name>` or the MCP `get_template` tool.
+2. Modify it for the user's request (different styling, different fields, chart library, etc.).
+3. Hand the user the modified file as an artifact.
+
+The live engine is documented at [`/docs/BUILDING_WITH_THE_ENGINE.md`](../docs/BUILDING_WITH_THE_ENGINE.md).
+
+## License
+
+MIT. Fork freely. If you use Rabbi Zajac's teaching content (class transcripts),
+credit Rabbi Zajac and link to [Chabad.org](https://www.chabad.org).

--- a/templates/node-cli.mjs
+++ b/templates/node-cli.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * Kiddush HaChodesh — Node CLI
+ * ============================
+ * Run the Rambam's full astronomical pipeline for any Gregorian date,
+ * right from the terminal. Works with `node` >= 18 (native fetch + ESM).
+ *
+ *   node node-cli.mjs                 # today
+ *   node node-cli.mjs 2026-04-07      # specific date
+ *
+ * Uses the live engine hosted at the project site (no install needed).
+ * To vendor a local copy instead, replace ENGINE_URL with a path to your
+ * cloned `src/engine/pipeline.js`.
+ *
+ * Source: https://github.com/rayistern/kidushhachodesh (MIT)
+ * Teachings by Rabbi Zajac via Chabad.org (https://www.chabad.org).
+ */
+
+const ENGINE_URL = 'https://kidushhachodesh.netlify.app/engine/pipeline.js';
+
+const { getFullCalculation } = await import(ENGINE_URL);
+
+const arg = process.argv[2];
+const date = arg ? new Date(arg + 'T12:00:00Z') : new Date();
+if (Number.isNaN(date.getTime())) {
+  console.error('Invalid date. Use YYYY-MM-DD.');
+  process.exit(1);
+}
+
+const calc = getFullCalculation(date);
+
+console.log(`\nKiddush HaChodesh — ${date.toISOString().slice(0, 10)}\n`);
+console.log(`  Days from epoch:   ${calc.daysFromEpoch}`);
+console.log(`  Sun true lon:      ${calc.sun.trueLongitude.toFixed(4)}° (${calc.sun.constellation.english})`);
+console.log(`  Moon true lon:     ${calc.moon.trueLongitude.toFixed(4)}° (${calc.moon.constellation.english})`);
+console.log(`  Elongation:        ${calc.moon.elongation.toFixed(4)}°`);
+console.log(`  Moon phase:        ${calc.moon.phaseHebrew}`);
+console.log(`  Visible tonight?   ${calc.moon.isVisible ? 'yes' : 'no'}`);
+console.log(`  Season:            ${calc.season}\n`);
+
+console.log('All pipeline steps:');
+for (const s of calc.steps) {
+  const val = typeof s.result === 'number' ? s.result.toFixed(4) : s.result;
+  console.log(`  [${s.rambamRef || '     '}]  ${s.name.padEnd(30)} = ${val} ${s.unit || ''}`);
+}

--- a/templates/standalone-calculator.html
+++ b/templates/standalone-calculator.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<!--
+  Kiddush HaChodesh — Standalone Calculator
+  ==========================================
+  A single HTML file that computes the Rambam's full astronomical pipeline
+  for any Gregorian date, by importing the live engine from the project site.
+
+  No build step, no dependencies. Drop this file anywhere (or paste it into
+  a Claude Artifact / ChatGPT canvas) and it will work.
+
+  Replace ENGINE_BASE with your deployment URL if you're self-hosting.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Kiddush HaChodesh — Standalone Calculator</title>
+    <style>
+      body { font: 15px/1.5 system-ui, sans-serif; max-width: 820px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }
+      h1 { margin-bottom: 0.2em; }
+      .sub { color: #666; margin-top: 0; }
+      label { display: block; margin: 1rem 0 0.3rem; font-weight: 600; }
+      input[type=date] { font: inherit; padding: 0.4rem 0.6rem; border: 1px solid #ccc; border-radius: 6px; }
+      button { font: inherit; padding: 0.5rem 1rem; border: 0; background: #2b6cb0; color: white; border-radius: 6px; cursor: pointer; margin-left: 0.5rem; }
+      table { border-collapse: collapse; margin-top: 1rem; width: 100%; }
+      th, td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid #eee; font-size: 14px; }
+      th { background: #f5f5f5; }
+      td.num { font-family: ui-monospace, monospace; text-align: right; }
+      .ref { color: #888; font-size: 12px; }
+      footer { margin-top: 3rem; color: #888; font-size: 13px; }
+    </style>
+  </head>
+  <body>
+    <h1>Kiddush HaChodesh Calculator</h1>
+    <p class="sub">Rambam's full pipeline — sun, moon, and visibility — for any Gregorian date.</p>
+
+    <label for="d">Date</label>
+    <input type="date" id="d" />
+    <button id="go">Calculate</button>
+
+    <div id="out"></div>
+
+    <footer>
+      Engine imported live from
+      <a id="src" href="#">/engine/pipeline.js</a>.
+      Source: <a href="https://github.com/rayistern/kidushhachodesh">github.com/rayistern/kidushhachodesh</a> (MIT).
+      Teachings by Rabbi Zajac via <a href="https://www.chabad.org">Chabad.org</a>.
+    </footer>
+
+    <script type="module">
+      // Change this to your deployment if self-hosting.
+      const ENGINE_BASE = new URL('.', location.href).origin;
+      document.getElementById('src').href = ENGINE_BASE + '/engine/pipeline.js';
+
+      const { getFullCalculation } = await import(ENGINE_BASE + '/engine/pipeline.js');
+
+      const dateInput = document.getElementById('d');
+      dateInput.value = new Date().toISOString().slice(0, 10);
+
+      document.getElementById('go').addEventListener('click', run);
+      run();
+
+      function run() {
+        const d = new Date(dateInput.value + 'T12:00:00Z');
+        const calc = getFullCalculation(d);
+        const out = document.getElementById('out');
+        out.innerHTML = `
+          <h2>Summary</h2>
+          <table>
+            <tr><td>Sun true longitude</td><td class="num">${fmt(calc.sun.trueLongitude)}°</td></tr>
+            <tr><td>Moon true longitude</td><td class="num">${fmt(calc.moon.trueLongitude)}°</td></tr>
+            <tr><td>Elongation</td><td class="num">${fmt(calc.moon.elongation)}°</td></tr>
+            <tr><td>Moon phase</td><td>${calc.moon.phaseHebrew} (${fmt(calc.moon.phase)})</td></tr>
+            <tr><td>Visible at sunset?</td><td>${calc.moon.isVisible ? 'yes' : 'no'}</td></tr>
+            <tr><td>Sun constellation</td><td>${calc.sun.constellation.english} / ${calc.sun.constellation.hebrew}</td></tr>
+            <tr><td>Moon constellation</td><td>${calc.moon.constellation.english} / ${calc.moon.constellation.hebrew}</td></tr>
+          </table>
+          <h2>All steps</h2>
+          <table>
+            <tr><th>Step</th><th>Rambam</th><th>Result</th></tr>
+            ${calc.steps.map((s) => `
+              <tr>
+                <td>${s.name}<div class="ref">${s.hebrewName || ''}</div></td>
+                <td class="ref">${s.rambamRef || ''}</td>
+                <td class="num">${fmt(s.result)} ${s.unit || ''}</td>
+              </tr>`).join('')}
+          </table>
+        `;
+      }
+
+      function fmt(v) {
+        if (typeof v !== 'number') return String(v);
+        return v.toFixed(4);
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
One URL, two doors: browsing AIs read /llms.txt, /agents.md, and /docs/*.md;
MCP-aware clients POST JSON-RPC to /mcp (search, fetch, calculate tools).
Both paths reuse the same calculation engine and docs.

- public/llms.txt, public/agents.md: agent-directed site map
- netlify/functions/mcp.mjs: minimal Streamable-HTTP MCP server
- netlify/functions/{search,calculate,doc}.mjs: plain HTTP API
- netlify/functions/_lib.mjs: shared search/fetch/pipeline helpers
- netlify.toml: bundle docs/ + src/engine/ into functions