### PR TITLE
chore: clean up stale constants — phase B sync (partial #15)

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -85,8 +85,10 @@ export const CONSTANTS = {
     START_CONSTELLATION: 0, // Aries
     APOGEE_START: { degrees: 26, minutes: 45, seconds: 8 },
     APOGEE_CONSTELLATION: 2, // Gemini
-    APOGEE_MOTION_PER_DAY: 1.5 / 3600, // 1.5 seconds per day
-    APOGEE_MOTION_PER_DAY_ARCSEC: 1.5,
+    // KH 12:2 — "1.5 sheniot PER 10 DAYS" = 0.15"/day. Synced with
+    // src/engine/constants.js per issue #15 (was 1.5"/day, 10× too fast).
+    APOGEE_MOTION_PER_DAY: 0.15 / 3600,
+    APOGEE_MOTION_PER_DAY_ARCSEC: 0.15,
     
     // Epicycle data (galgal katan)
     EPICYCLE: {
@@ -101,13 +103,15 @@ export const CONSTANTS = {
   },
   
   MOON: {
-    // 13° 10′ 35 4⁄30″  – Rambam KH 11:7
-    MEAN_MOTION_PER_DAY: { degrees: 13, minutes: 10, seconds: 35.133 },
+    // 13° 10′ 35″ – Rambam KH 14:1 (his 10-day table of 131°45'50" implies this rate).
+    // Synced with src/engine/constants.js per issue #15 (was 35.133, undocumented deviation).
+    MEAN_MOTION_PER_DAY: { degrees: 13, minutes: 10, seconds: 35 },
     // KH 14:4 — mean longitude at the epoch is 1°14'43" in Taurus.
     START_POSITION: { degrees: 1, minutes: 14, seconds: 43 },
     START_CONSTELLATION: 1, // Taurus
-    // 13° 3′ 53⅓″
-    MASLUL_MEAN_MOTION: { degrees: 13, minutes: 3, seconds: 53.333 },
+    // 13° 3′ 54″ – Rambam KH 14:3 ("י"ג מַעֲלוֹת וּשְׁלֹשָׁה חֲלָקִים וְנ"ד שְׁנִיּוֹת").
+    // Synced with src/engine/constants.js per issue #15 (was 53.333, undocumented deviation).
+    MASLUL_MEAN_MOTION: { degrees: 13, minutes: 3, seconds: 54 },
     MASLUL_START: { degrees: 84, minutes: 28, seconds: 42 },
     
     // Moon's galgalim (celestial spheres) parameters

--- a/src/engine/constants.js
+++ b/src/engine/constants.js
@@ -220,8 +220,8 @@ export const CONSTANTS = {
       },
       GALGAL_KATAN: {
         description: "The small epicycle — moon sits on its edge, 5° radius",
-        // [R] KH 14:2 — moves 13° 3' 53.33" per day
-        DAILY_MOTION: 13 + 3 / 60 + 53.333 / 3600,
+        // [R] KH 14:3 — moves 13° 3' 54" per day (matches MOON.MASLUL_MEAN_MOTION)
+        DAILY_MOTION: 13 + 3 / 60 + 54 / 3600,
         // [R] KH 15:9 — diameter is 10°, so radius is 5° (the Rambam writes 5°5' from our perspective)
         RADIUS_DEGREES: 5,
         color: '#dddd44',


### PR DESCRIPTION
## Summary

Phase **B** of the three-phase cleanup laid out in #15. Sync values only — no deprecation banners and no deletions in this PR.

## What landed

**`src/constants.js`** — the dead duplicate constants file. Brought in line with `src/engine/constants.js` for the three rates corrected during the Phase R engine purism rework (`ca82420`, see `docs/OPEN_QUESTIONS.md` Q7):

- `SUN.APOGEE_MOTION_PER_DAY`: `1.5 / 3600` → `0.15 / 3600` (was 10× too fast)
- `SUN.APOGEE_MOTION_PER_DAY_ARCSEC`: `1.5` → `0.15` (matching sibling)
- `MOON.MEAN_MOTION_PER_DAY.seconds`: `35.133` → `35`
- `MOON.MASLUL_MEAN_MOTION.seconds`: `53.333` → `54`

**`src/engine/constants.js`** — fixed the stray `53.333` in `MOON.GALGALIM.GALGAL_KATAN.DAILY_MOTION` (line 224) to `54` so it matches `MOON.MASLUL_MEAN_MOTION` and won't confuse a future grepper. The object isn't read by the active app, but the file is live, so the value is fixed in place rather than left to rot.

Each replaced value carries an inline comment noting the prior bad value and citing #15, so future agents grepping for `35.133` etc. will still hit a hit explaining what happened, rather than a phantom-clean file.

## Verification

- `npx vitest run` — **50/50 passing**
- `npx vite build` — **clean**
- `grep -rE "35\\.133|53\\.333|1\\.5 / 3600" src/` — only matches in the new explanatory comments (no live values)

## Deferred to later PRs

Per #15, the remaining phases will land separately:

- **Phase C — mark deprecated**: add a top-of-file `DEPRECATED — pending retirement` banner to `src/constants.js`, the legacy `src/utils/astronomy*.js` calculators, and the legacy UI components (`CelestialVisualization`, `AstronomicalCalculations`, `HebrewDateInput`, `CustomDatePicker`, `DateControl`, `KnowledgeBase`, `MathematicalModel`).
- **Phase A — delete**: remove the dead files entirely once the deprecation banner has soaked.

## Test plan

- [x] `npx vitest run` — 50/50 passing
- [x] `npx vite build` — clean
- [x] grep confirms no remaining live occurrences of `35.133`, `53.333`, or `1.5 / 3600` outside explanatory comments
- [ ] Manual smoke check of the live dashboard (sidebar / 3D / ribbon) — not required since this PR only edits dead code paths and an unreferenced sub-object, but worth a quick eyeball before merging

Refs #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)