### PR TITLE
Book batch 2

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ const TextIndex = React.lazy(() => import('./components/text/TextIndex'));
 const TextChapter = React.lazy(() => import('./components/text/TextChapter'));
 const BookIndex = React.lazy(() => import('./components/book/BookIndex'));
 const BookChapter = React.lazy(() => import('./components/book/BookChapter'));
+const ThirteenNumbers = React.lazy(() => import('./components/book/ThirteenNumbers'));
 const SkyPage = React.lazy(() => import('./components/sky/SkyPage'));
 
 const Fallback = () => (
@@ -70,6 +71,9 @@ export default function App() {
           <Route path="/text/:chapter" element={<TextChapter />} />
           {/* Plain-language companion — one chapter at a time, KH 14 first. */}
           <Route path="/book" element={<BookIndex />} />
+          {/* Standalone article: the thirteen numbers everything stands on.
+              Must precede :chapter, which would otherwise swallow it. */}
+          <Route path="/book/numbers" element={<ThirteenNumbers />} />
           <Route path="/book/:chapter" element={<BookChapter />} />
           {/* The book's numbers drawn on the real evening sky. */}
           <Route path="/sky" element={<SkyPage />} />

--- a/src/components/book/BookIndex.jsx
+++ b/src/components/book/BookIndex.jsx
@@ -56,6 +56,10 @@ export default function BookIndex() {
           <Link to="/sky" className="text-[var(--color-accent)] hover:underline">
             the Sky page
           </Link>
+          . Short on time? The whole method's foundations fit on one page:{' '}
+          <Link to="/book/numbers" className="text-[var(--color-accent)] hover:underline">
+            Thirteen numbers
+          </Link>
           .
         </p>
 

--- a/src/components/book/ThirteenNumbers.jsx
+++ b/src/components/book/ThirteenNumbers.jsx
@@ -188,6 +188,45 @@ export default function ThirteenNumbers() {
         </section>
 
         <section>
+          <h2 className="text-base font-bold">The two odd ones, and why they earn their place</h2>
+          <p className="mt-2">
+            Three of the five are self-explanatory — you need to know where the sun and moon are,
+            and the maslul is the moon's version of the story below. The other two look like
+            bookkeeping and are anything but.
+          </p>
+          <p className="mt-2">
+            <strong>The slow point (apogee)</strong> is where the sun's unevenness is anchored.
+            The sun drags near that point and hurries opposite it, and{' '}
+            <Link to="/book/13" className="text-[var(--color-accent)] hover:underline">
+              chapter 13's correction
+            </Link>{' '}
+            is looked up entirely by the sun's distance from it — reaching{' '}
+            <strong>1° 59′</strong> at ninety degrees away. Skip it and you are stuck with the
+            pretend sun, wrong by up to two degrees — and that error lands one-for-one in{' '}
+            <strong>the gap</strong> (moon minus sun), on which the verdict lives, with its
+            thresholds only single degrees apart. It is also why the seasons run unequal lengths;
+            and its crawl of a degree per seventy years is stated so the method would not quietly
+            expire — by now it has drifted a whole sign's worth of thirteen degrees.
+          </p>
+          <p className="mt-2">
+            <strong>The crossing point (node)</strong> is where the moon's tilt is anchored. The
+            moon does not ride the sun's road; its path is tilted against it, and{' '}
+            <Link to="/book/16" className="text-[var(--color-accent)] hover:underline">
+              chapter 16
+            </Link>{' '}
+            turns the moon's distance from the crossing into its <strong>height off the road —
+            up to 5°, north or south</strong>. That one number is the heaviest lever in the
+            verdict: it decides whether the crescent hangs above the road or below it at dusk,
+            and in the chain's last step two thirds of it swing the arc by more than three
+            degrees between a northern moon and a southern one. It also explains why there is no
+            eclipse of the sun every month — the monthly pass almost always sails above or below,
+            and only a meeting near a crossing truly lines up. And because the crossing walks{' '}
+            <em>backwards</em> (his 3′ 11″ a day works out to a full lap in about 18.6 years),
+            the pattern of high-riding and low-riding crescents slides slowly through the years.
+          </p>
+        </section>
+
+        <section>
           <h2 className="text-base font-bold">What the famous tables are not</h2>
           <p className="mt-2">
             The correction tables — the sun's (KH 13), the moon's (KH 15), the latitude rule with

--- a/src/components/book/ThirteenNumbers.jsx
+++ b/src/components/book/ThirteenNumbers.jsx
@@ -190,9 +190,12 @@ export default function ThirteenNumbers() {
         <section>
           <h2 className="text-base font-bold">The two odd ones, and why they earn their place</h2>
           <p className="mt-2">
-            Three of the five are self-explanatory — you need to know where the sun and moon are,
-            and the maslul is the moon's version of the story below. The other two look like
-            bookkeeping and are anything but.
+            Where the sun and the moon are needs no argument. The <strong>maslul</strong> is the
+            same story as the sun's slow point, told of the moon: the moon also drags and hurries
+            around its circle, and the maslul is where it currently stands in that
+            drag-and-hurry cycle — chapter 15's correction is looked up by it, just as chapter
+            13's is looked up by the sun's distance from the slow point. The remaining two look
+            like bookkeeping and are anything but.
           </p>
           <p className="mt-2">
             <strong>The slow point (apogee)</strong> is where the sun's unevenness is anchored.

--- a/src/components/book/ThirteenNumbers.jsx
+++ b/src/components/book/ThirteenNumbers.jsx
@@ -107,6 +107,41 @@ export default function ThirteenNumbers() {
 
       <main className="mx-auto max-w-3xl px-4 sm:px-6 py-6 space-y-6 text-sm leading-relaxed">
         <section>
+          <h2 className="text-base font-bold">Start at the window</h2>
+          <p className="mt-2">
+            Stand at a west-facing window — or on the mountaintop, with KH 18:1's watchers — on
+            the evening after the 29th of the month. One question: <strong>will a thin crescent
+            show tonight?</strong> Everything below exists to answer it, and it is worth feeling
+            how much the innocent question actually demands (
+            <Link to="/sky" className="text-[var(--color-accent)] hover:underline">
+              the Sky page
+            </Link>{' '}
+            draws all of it on the window itself).
+          </p>
+          <p className="mt-2">
+            Knowing where the moon is isn't enough. A crescent that thin shows only against a
+            sky dark enough to lose to it — so first you must know <strong>how dark it will be,
+            and when</strong>: that is, exactly where the sun is and when it goes down. And the
+            sun refuses to be simple about it. It does not run at one speed — some stretches of
+            the year it hurries, others it drags — so its true place is never quite where an
+            even-paced sun would be. And it does not set in one place: watch from the same
+            window through a year and the setting point swings along the horizon, and with it the{' '}
+            <strong>angle</strong> the sun's path cuts down through the horizon — which sets how
+            fast the sky darkens, and how a given separation between moon and sun translates
+            into the moon standing clear of the glow or drowning in it.
+          </p>
+          <p className="mt-2">
+            The moon is worse. Everything the sun does wrong it does too — its own drag and
+            hurry, faster and bigger — and then one more: it does not even ride the sun's road,
+            but a path tilted against it, so it stands now above the road, now below, by up to
+            ten of the sun's widths. So the window question needs three things the eye cannot
+            supply in advance: where the sun truly is, where the moon truly is, and how the two
+            will sit against the horizon at dusk. The whole method is the shortest honest path
+            to those three — and the path runs through exactly thirteen numbers.
+          </p>
+        </section>
+
+        <section>
           <h2 className="text-base font-bold">One pattern, everywhere</h2>
           <p className="mt-2">
             Strip away the tables and the vocabulary and every calculation in the whole method is

--- a/src/components/book/ThirteenNumbers.jsx
+++ b/src/components/book/ThirteenNumbers.jsx
@@ -109,35 +109,52 @@ export default function ThirteenNumbers() {
         <section>
           <h2 className="text-base font-bold">Start at the window</h2>
           <p className="mt-2">
-            Stand at a west-facing window — or on the mountaintop, with KH 18:1's watchers — on
-            the evening after the 29th of the month. One question: <strong>will a thin crescent
-            show tonight?</strong> Everything below exists to answer it, and it is worth feeling
-            how much the innocent question actually demands (
+            Picture someone standing at a window that faces west, on the evening after the 29th
+            day of the month. Tonight might be the night the new moon shows. The question is
+            simple: <strong>will they see the thin crescent tonight, or not?</strong> Every
+            number on this page exists to answer that one question. (
             <Link to="/sky" className="text-[var(--color-accent)] hover:underline">
-              the Sky page
+              The Sky page
             </Link>{' '}
-            draws all of it on the window itself).
+            draws this exact view, evening by evening.)
           </p>
           <p className="mt-2">
-            Knowing where the moon is isn't enough. A crescent that thin shows only against a
-            sky dark enough to lose to it — so first you must know <strong>how dark it will be,
-            and when</strong>: that is, exactly where the sun is and when it goes down. And the
-            sun refuses to be simple about it. It does not run at one speed — some stretches of
-            the year it hurries, others it drags — so its true place is never quite where an
-            even-paced sun would be. And it does not set in one place: watch from the same
-            window through a year and the setting point swings along the horizon, and with it the{' '}
-            <strong>angle</strong> the sun's path cuts down through the horizon — which sets how
-            fast the sky darkens, and how a given separation between moon and sun translates
-            into the moon standing clear of the glow or drowning in it.
+            Start with what makes the question hard. The new crescent is very thin and very
+            faint. You can only see it once the sky has grown dark enough — and the moon has to
+            still be up when that happens. There is the problem: a new crescent always hangs
+            close to the sun, so it sets shortly after the sun does. That leaves only a short
+            stretch of time between "the sky is finally dark enough" and "the moon has already
+            gone down." To predict whether tonight offers that stretch at all, you have to know
+            exactly where the sun is and when it sets.
           </p>
           <p className="mt-2">
-            The moon is worse. Everything the sun does wrong it does too — its own drag and
-            hurry, faster and bigger — and then one more: it does not even ride the sun's road,
-            but a path tilted against it, so it stands now above the road, now below, by up to
-            ten of the sun's widths. So the window question needs three things the eye cannot
-            supply in advance: where the sun truly is, where the moon truly is, and how the two
-            will sit against the horizon at dusk. The whole method is the shortest honest path
-            to those three — and the path runs through exactly thirteen numbers.
+            You might think that part is easy — the sun seems like the most regular thing in the
+            world. It is not, in two ways. First, <strong>the sun does not travel at one steady
+            speed</strong> through the year. In some seasons it covers a little more of its path
+            each day, in others a little less. So if you predict the sun's position by assuming
+            a steady pace, your prediction slowly drifts away from where the sun actually is.
+            Second, <strong>the sun does not set at the same spot</strong>. Watch the sunset
+            from the same window for a year: the setting point slides along the horizon, well to
+            the north of due west in summer, well to the south in winter. And as the spot
+            moves, the <strong>angle</strong> at which the sun drops below the horizon changes
+            too. That angle matters twice over: it controls how quickly the sky gets dark after
+            sunset, and it controls what a given distance between the moon and the sun is worth
+            — whether that distance stands the moon well above the sunset glow, or leaves it
+            sitting low inside the glow where no eye will find it.
+          </p>
+          <p className="mt-2">
+            And the moon is harder than the sun. It has its own uneven speed — with bigger
+            swings, changing faster. And it does not even travel along the same line in the sky
+            that the sun does: the moon's path is tilted against the sun's, so in some months
+            the moon rides above the sun's path and in others below it, by up to five degrees —
+            about ten times the width of the sun itself.
+          </p>
+          <p className="mt-2">
+            So the simple window question — <em>will I see it tonight?</em> — turns out to need
+            three things that nobody can just see in advance: where the sun really is, where the
+            moon really is, and how the two of them will be arranged against the horizon when
+            the sky darkens. The rest of this page lists the numbers the Rambam gives for
+            working those three things out — and there are exactly thirteen of them.
           </p>
         </section>
 

--- a/src/components/book/ThirteenNumbers.jsx
+++ b/src/components/book/ThirteenNumbers.jsx
@@ -1,0 +1,227 @@
+/**
+ * ThirteenNumbers — the whole method's foundations, on one page.
+ *
+ * ═══════════════════════════════════════════════════════════════════
+ *  REGIME TAG: **editorial** — NOT the Rambam, NOT a translation.
+ *  SURFACE CATEGORY: teaching commentary (standalone article)
+ * ═══════════════════════════════════════════════════════════════════
+ *
+ * Grew out of a reader's question — "what are the most fundamental
+ * numbers to calculate?" — whose answer turned out to be short enough
+ * to be an article and load-bearing enough to deserve one: three
+ * numbers run the calendar, five positions with five speeds run the
+ * astronomy, and every evening they funnel into one number.
+ *
+ * Every figure on this page is rendered FROM the engine's constants,
+ * not typed in, so the article cannot drift from the code — pinned in
+ * thirteenNumbers.test.jsx. The counting-to-thirteen framing is this
+ * book's; the numbers themselves are his, each with its chapter.
+ */
+import React from 'react';
+import { Link } from 'react-router-dom';
+import SiteCredit from '../layout/SiteCredit';
+import { CONSTANTS } from '../../engine/constants';
+import {
+  BAHARAD,
+  SYNODIC_MONTH_PARTS,
+  PARTS_PER_DAY,
+  PARTS_PER_HOUR,
+} from '../../engine/fixedCalendar/constants';
+
+// The month, decomposed from the engine's single parts figure.
+const MONTH_DAYS = Math.floor(SYNODIC_MONTH_PARTS / PARTS_PER_DAY);
+const MONTH_HOURS = Math.floor((SYNODIC_MONTH_PARTS % PARTS_PER_DAY) / PARTS_PER_HOUR);
+const MONTH_PARTS = SYNODIC_MONTH_PARTS % PARTS_PER_HOUR;
+
+/** d-m-s object → the book's inline style: 13° 10′ 35″. */
+function dms({ degrees, minutes, seconds }) {
+  const s = Math.round(seconds * 100) / 100;
+  return `${degrees}° ${minutes}′ ${s ? `${s}″` : ''}`.trim();
+}
+
+const SUN = CONSTANTS.SUN;
+const MOON = CONSTANTS.MOON;
+const NODE = CONSTANTS.NODE;
+
+/** The five running quantities: anchor at the epoch, speed, and where he states them. */
+const PAIRS = [
+  {
+    name: "The sun's mean place",
+    hebrew: 'אמצע השמש',
+    epoch: `${dms(SUN.START_POSITION)} of the 1st sign`,
+    rate: `${dms(SUN.MEAN_MOTION_PER_DAY)} a day`,
+    ref: 'KH 12:1-2',
+    note: 'He prints the rate as 59′ 8″; his own worked example and his 10-day table both need the extra third of a second, so that is the operative figure.',
+  },
+  {
+    name: "The sun's slow point (apogee)",
+    hebrew: 'גובה השמש',
+    epoch: `${dms(SUN.APOGEE_START)} of the 3rd sign`,
+    rate: '1.5″ every 10 days',
+    ref: 'KH 12:2',
+    note: 'The crawl of the whole solar circle — about a degree in seventy years.',
+  },
+  {
+    name: "The moon's mean place",
+    hebrew: 'אמצע הירח',
+    epoch: `${dms(MOON.START_POSITION)} of the 2nd sign`,
+    rate: `${dms(MOON.MEAN_MOTION_PER_DAY)} a day`,
+    ref: 'KH 14:1, 14:4',
+    note: 'The fastest thing in the sky — a whole circle in under a month.',
+  },
+  {
+    name: "The moon's place on its own wobble (maslul)",
+    hebrew: 'אמצע המסלול',
+    epoch: dms(MOON.MASLUL_START),
+    rate: `${dms(MOON.MASLUL_MEAN_MOTION)} a day`,
+    ref: 'KH 14:3-4',
+    note: 'Slightly slower than the moon itself, which is why the wobble slides.',
+  },
+  {
+    name: 'The crossing point (node)',
+    hebrew: 'הראש',
+    epoch: dms(NODE.START_POSITION),
+    rate: `${dms(NODE.DAILY_MOTION)} a day — backwards`,
+    ref: 'KH 16:2-3',
+    note: "Where the moon's tilted path cuts the sun's road; the only one that runs against the traffic.",
+  },
+];
+
+export default function ThirteenNumbers() {
+  return (
+    <div className="min-h-[100dvh] bg-[var(--color-bg)] text-[var(--color-text)]">
+      <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 py-5 flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="text-xl sm:text-2xl font-bold">Thirteen numbers</h1>
+            <p className="mt-1 text-sm text-[var(--color-text-secondary)]">
+              Everything the nineteen chapters do stands on thirteen numbers the Rambam states
+              outright — and funnels into one.
+            </p>
+          </div>
+          <Link to="/book" className="shrink-0 text-sm text-[var(--color-accent)] hover:underline">
+            ← The book
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-4 sm:px-6 py-6 space-y-6 text-sm leading-relaxed">
+        <section>
+          <h2 className="text-base font-bold">One pattern, everywhere</h2>
+          <p className="mt-2">
+            Strip away the tables and the vocabulary and every calculation in the whole method is
+            the same move: <strong>take an anchor, add a speed times the days elapsed, throw away
+            whole circles</strong>. It is how you read a clock — you don't ask where the hand has
+            been, only where it started and how fast it turns. So the method's real foundations
+            are exactly its anchors and its speeds, and there are thirteen of them.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-bold">The calendar's three (chapter 6)</h2>
+          <ol className="mt-2 list-decimal space-y-2 pl-5">
+            <li>
+              <strong>
+                The month: {MONTH_DAYS} days, {MONTH_HOURS} hours, {MONTH_PARTS} parts
+              </strong>{' '}
+              — the
+              mean time from one conjunction to the next (KH 6:3). The single most important
+              number in the system; chapters 6 through 10 are nothing but multiples of it with
+              the weeks thrown away.
+            </li>
+            <li>
+              <strong>
+                The anchor: molad of Tishrei, year one — day {BAHARAD.dayOfWeek} (Monday),{' '}
+                {BAHARAD.hours} hours, {BAHARAD.parts} parts
+              </strong>{' '}
+              — <span className="hebrew-text">בהר"ד</span> (KH 6:8). Every molad ever calculated
+              is this number plus whole months.
+            </li>
+            <li>
+              <strong>Seven leap years in every nineteen</strong> (KH 6:10-11) — the one number
+              that ties the moon's months to the sun's seasons, so Pesach stays in spring.
+            </li>
+          </ol>
+          <p className="mt-2 text-[13px] text-[var(--color-text-secondary)]">
+            Everything else in the fixed calendar — the year remainders, the cycle remainder, the
+            four postponements — is derived from these three or is a rule about them, not a new
+            measurement. The{' '}
+            <Link to="/book/6" className="text-[var(--color-accent)] hover:underline">
+              molad ladder in chapter 6
+            </Link>{' '}
+            is the three of them at work.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-bold">The astronomy's five pairs (chapters 12-16)</h2>
+          <p className="mt-2">
+            The sighting calculation adds one moment — <strong>the epoch</strong>, the eve of
+            Thursday, 3 Nisan 4938 (KH 11:16) — and for five quantities, where each stood that
+            evening and how fast it moves. Five anchors, five speeds: ten numbers.
+          </p>
+          <div className="mt-3 overflow-x-auto">
+            <table className="w-full min-w-[560px] text-[13px]">
+              <thead>
+                <tr className="border-b border-[var(--color-border)] text-left text-[var(--color-text-secondary)]">
+                  <th className="py-1 pr-3 font-bold">quantity</th>
+                  <th className="py-1 pr-3 font-bold">at the epoch</th>
+                  <th className="py-1 pr-3 font-bold">speed</th>
+                  <th className="py-1 font-bold">stated at</th>
+                </tr>
+              </thead>
+              <tbody>
+                {PAIRS.map((p) => (
+                  <tr key={p.name} className="border-b border-[var(--color-border)]/40 align-top">
+                    <td className="py-1.5 pr-3">
+                      {p.name} <span className="hebrew-text text-[var(--color-text-secondary)]">{p.hebrew}</span>
+                      <div className="text-[11px] text-[var(--color-text-secondary)]">{p.note}</div>
+                    </td>
+                    <td className="py-1.5 pr-3 font-mono whitespace-nowrap">{p.epoch}</td>
+                    <td className="py-1.5 pr-3 font-mono whitespace-nowrap">{p.rate}</td>
+                    <td className="py-1.5 font-mono text-[var(--color-text-secondary)] whitespace-nowrap">{p.ref}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-base font-bold">What the famous tables are not</h2>
+          <p className="mt-2">
+            The correction tables — the sun's (KH 13), the moon's (KH 15), the latitude rule with
+            its 5° ceiling (KH 16), chapter 17's by-sign tables — are <em>not</em> further
+            fundamentals. They are fixed recipes applied to the running numbers above: look up,
+            share out, add or subtract. Nothing in them is measured anew; once the thirteen are
+            set, the tables never change.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-base font-bold">Thirteen in, one out</h2>
+          <p className="mt-2">
+            Each evening the machinery exists to produce just three working numbers —{' '}
+            <strong>the sun's true place, the moon's true place, and the moon's height off the
+            sun's road</strong>. From those come the gap (
+            <span className="hebrew-text">אורך ראשון</span>) and the height (
+            <span className="hebrew-text">רוחב ראשון</span>), and after{' '}
+            <Link to="/book/17" className="text-[var(--color-accent)] hover:underline">
+              chapter 17's chain
+            </Link>{' '}
+            of corrections, the single number the verdict reads:{' '}
+            <span className="hebrew-text">קשת הראייה</span>, the arc of sighting. Thirteen numbers
+            in; a yes or a no out.
+          </p>
+        </section>
+
+        <p className="border-t border-[var(--color-border)] pt-3 text-[12px] leading-relaxed text-[var(--color-text-secondary)]">
+          Every number on this page is the Rambam's, from the chapter cited beside it — and this
+          page renders them from the same constants the calculators run on, so the two cannot
+          disagree. The framing — counting the foundations to thirteen — is this book's, not his.
+        </p>
+        <SiteCredit />
+      </main>
+    </div>
+  );
+}

--- a/src/components/book/interactives/Declination.jsx
+++ b/src/components/book/interactives/Declination.jsx
@@ -16,6 +16,13 @@
  * moon was the wave. Seeing the same drawing with the roles swapped is
  * the clearest way to say "different line".
  *
+ * Above the wave sits the sphere the wave unrolls: the dashboard's
+ * globe reduced to the two great circles this chapter needs (a reader's
+ * request). Same slider drives both, so "a wave on the flat drawing" and
+ * "a tilted circle on the sphere" visibly name one fact. Drawn as SVG
+ * orthographic projection — the 3D scene's three.js stays out of the
+ * book bundle.
+ *
  * The reality check is the closing note of the book: his table is right
  * to about a fifth of a degree, in the chapter he opens by apologising
  * for. It is NOT the most accurate table in the book — KH 13:4's sun
@@ -32,6 +39,7 @@ import {
   foldForDeclination,
 } from '../../../lib/khDeclination';
 import { CONSTANTS } from '../../../engine/constants';
+import { eclipticToEquatorial } from '../../../lib/skyView';
 
 const DEG = Math.PI / 180;
 /** The true tilt, for the comparison: arcsin(sin ε · sin λ). */
@@ -53,6 +61,7 @@ export default function Declination() {
       blurb="the sun's road is itself tilted, by up to 23½°"
       defaultOpen
     >
+      <Sphere longitude={longitude} tilt={tilt} />
       <Wave longitude={longitude} tilt={tilt} />
 
       <label className="mt-3 block">
@@ -125,6 +134,174 @@ export default function Declination() {
         tightest table in the book, but easily good enough that the apology was unnecessary.
       </p>
     </InteractiveCard>
+  );
+}
+
+/**
+ * The sphere itself: the equator and the sun's road as two great
+ * circles, crossing at Taleh and Moznayim — the dashboard's globe with
+ * everything else stripped away. Orthographic projection, the viewer
+ * standing a little above the equator's plane so both circles read.
+ * The dashed arc from the moving point down to the equator IS the
+ * chapter's quantity: how far that degree of the road is inclined.
+ */
+function Sphere({ longitude, tilt }) {
+  const w = 520;
+  const h = 240;
+  const cx = w / 2;
+  const cy = h / 2 + 6;
+  const R = 100;
+  // Camera height above the equator's plane. Not near 0° (the equator
+  // would collapse to a line) and not near 23½° (the road would): 40°
+  // keeps both circles open as ellipses.
+  const VIEW = 40 * DEG;
+  const EPS = MAX_TILT * DEG;
+
+  // Scene coords: x to the right (both circles cross there), z up,
+  // y toward the viewer. Tilt the scene toward the camera, project flat.
+  const project = ({ x, y, z }) => ({
+    X: cx + R * x,
+    Y: cy - R * (-y * Math.sin(VIEW) + z * Math.cos(VIEW)),
+    front: y * Math.cos(VIEW) + z * Math.sin(VIEW) > 0,
+  });
+  const equatorPt = (t) => project({ x: Math.cos(t), y: Math.sin(t), z: 0 });
+  const eclipticPt = (t) =>
+    project({ x: Math.cos(t), y: Math.sin(t) * Math.cos(EPS), z: Math.sin(t) * Math.sin(EPS) });
+
+  // A circle as front/back polylines, split where it dips behind the sphere.
+  const halves = (ptAt) => {
+    const segs = { front: [], back: [] };
+    let run = [];
+    let side = null;
+    for (let d = 0; d <= 360; d += 3) {
+      const p = ptAt(d * DEG);
+      const s = p.front ? 'front' : 'back';
+      if (side !== null && s !== side) {
+        segs[side].push(run);
+        run = [];
+      }
+      run.push(p);
+      side = s;
+    }
+    if (run.length) segs[side].push(run);
+    return segs;
+  };
+  const draw = (segs, color, width) =>
+    ['back', 'front'].map((side) =>
+      segs[side].map((seg, i) => (
+        <polyline
+          key={`${side}${i}`}
+          points={seg.map((p) => `${p.X.toFixed(1)},${p.Y.toFixed(1)}`).join(' ')}
+          fill="none"
+          stroke={color}
+          strokeWidth={width}
+          strokeOpacity={side === 'front' ? 0.9 : 0.28}
+          strokeDasharray={side === 'front' ? undefined : '3 3'}
+        />
+      )),
+    );
+
+  // The moving point, and its meridian arc down to the equator — the
+  // declination made visible as an arc on the sphere itself.
+  const lam = longitude * DEG;
+  const moving = eclipticPt(lam);
+  const { ra, dec } = eclipticToEquatorial(longitude, 0);
+  const meridian = [];
+  const steps = 24;
+  for (let i = 0; i <= steps; i++) {
+    const d = (dec * i) / steps;
+    meridian.push(
+      project({
+        x: Math.cos(d * DEG) * Math.cos(ra * DEG),
+        y: Math.cos(d * DEG) * Math.sin(ra * DEG),
+        z: Math.sin(d * DEG),
+      }),
+    );
+  }
+  const foot = meridian[0];
+
+  const taleh = equatorPt(0);
+  const moznayim = equatorPt(Math.PI);
+  const pole = project({ x: 0, y: 0, z: 1 });
+  const roadTop = eclipticPt(90 * DEG);
+  const equatorFrontMid = equatorPt(90 * DEG);
+
+  return (
+    <figure className="mb-3">
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        className="w-full"
+        role="img"
+        aria-label="A sphere carrying two great circles: the equator, and the sun's road tilted 23 and a half degrees against it, crossing at the start of Taleh and the start of Moznayim; a dashed arc drops from a point on the road to the equator, showing its inclination"
+      >
+        <circle cx={cx} cy={cy} r={R} fill="var(--color-card)" fillOpacity="0.5" stroke="var(--color-border)" strokeWidth="1" />
+
+        {draw(halves(equatorPt), 'var(--color-silver)', 1.5)}
+        {draw(halves(eclipticPt), 'var(--color-gold)', 1.5)}
+
+        {/* the two crossings */}
+        {[
+          { p: taleh, label: 'Taleh 0°', dx: 8, anchor: 'start' },
+          { p: moznayim, label: 'Moznayim 180°', dx: -8, anchor: 'end' },
+        ].map(({ p, label, dx, anchor }) => (
+          <g key={label}>
+            <circle cx={p.X} cy={p.Y} r="3.5" fill="var(--color-accent)" />
+            <text x={p.X + dx} y={p.Y + 3} fontSize="9" textAnchor={anchor} fill="var(--color-accent)">
+              {label}
+            </text>
+          </g>
+        ))}
+
+        {/* the pole of the equator, which every meridian runs through */}
+        <circle cx={pole.X} cy={pole.Y} r="2" fill="var(--color-silver)" fillOpacity="0.8" />
+        <text x={pole.X} y={pole.Y - 6} fontSize="8" textAnchor="middle" fill="var(--color-text-secondary)">
+          the pole of the equator
+        </text>
+
+        {/* labels on the circles themselves */}
+        <text x={equatorFrontMid.X + 4} y={equatorFrontMid.Y + 12} fontSize="9" fill="var(--color-silver)">
+          the equator
+        </text>
+        <text x={roadTop.X + 4} y={roadTop.Y - 6} fontSize="9" fill="var(--color-gold)">
+          the sun's road
+        </text>
+
+        {/* declination arc: the chapter's own quantity, on the sphere */}
+        <polyline
+          points={meridian.map((p) => `${p.X.toFixed(1)},${p.Y.toFixed(1)}`).join(' ')}
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth="1.25"
+          strokeDasharray="2 2"
+          strokeOpacity={moving.front ? 0.9 : 0.4}
+        />
+        <circle cx={foot.X} cy={foot.Y} r="2.5" fill="var(--color-accent)" fillOpacity="0.7" />
+        <circle
+          cx={moving.X}
+          cy={moving.Y}
+          r="5.5"
+          fill="var(--color-accent)"
+          fillOpacity={moving.front ? 1 : 0.45}
+          stroke="var(--color-bg)"
+          strokeWidth="1.5"
+        />
+        <text
+          x={moving.X}
+          y={moving.Y - 10}
+          fontSize="9"
+          textAnchor="middle"
+          fill="var(--color-accent)"
+          fillOpacity={moving.front ? 1 : 0.55}
+        >
+          {Math.abs(tilt) < 0.05 ? 'on the equator' : `${Math.abs(tilt).toFixed(1)}° ${tilt > 0 ? 'north' : 'south'}`}
+        </text>
+      </svg>
+      <figcaption className="mt-1 text-center text-[11px] text-[var(--color-text-secondary)]">
+        The dashboard's globe, cut down to the two lines this chapter needs. The gold circle is
+        tilted 23½° against the silver one; the dashed arc dropping to the equator is exactly the
+        quantity KH 19:7 tabulates. The wave below is this same picture unrolled flat.
+      </figcaption>
+    </figure>
   );
 }
 

--- a/src/components/book/interactives/Declination.jsx
+++ b/src/components/book/interactives/Declination.jsx
@@ -40,6 +40,12 @@ import {
 } from '../../../lib/khDeclination';
 import { CONSTANTS } from '../../../engine/constants';
 import { eclipticToEquatorial } from '../../../lib/skyView';
+import {
+  makeSphereProjector,
+  flatCircle,
+  tiltedCircle,
+  circleHalvesProps,
+} from './sphereProjection';
 
 const DEG = Math.PI / 180;
 /** The true tilt, for the comparison: arcsin(sin ε · sin λ). */
@@ -154,52 +160,13 @@ function Sphere({ longitude, tilt }) {
   // Camera height above the equator's plane. Not near 0° (the equator
   // would collapse to a line) and not near 23½° (the road would): 40°
   // keeps both circles open as ellipses.
-  const VIEW = 40 * DEG;
   const EPS = MAX_TILT * DEG;
-
-  // Scene coords: x to the right (both circles cross there), z up,
-  // y toward the viewer. Tilt the scene toward the camera, project flat.
-  const project = ({ x, y, z }) => ({
-    X: cx + R * x,
-    Y: cy - R * (-y * Math.sin(VIEW) + z * Math.cos(VIEW)),
-    front: y * Math.cos(VIEW) + z * Math.sin(VIEW) > 0,
-  });
-  const equatorPt = (t) => project({ x: Math.cos(t), y: Math.sin(t), z: 0 });
-  const eclipticPt = (t) =>
-    project({ x: Math.cos(t), y: Math.sin(t) * Math.cos(EPS), z: Math.sin(t) * Math.sin(EPS) });
-
-  // A circle as front/back polylines, split where it dips behind the sphere.
-  const halves = (ptAt) => {
-    const segs = { front: [], back: [] };
-    let run = [];
-    let side = null;
-    for (let d = 0; d <= 360; d += 3) {
-      const p = ptAt(d * DEG);
-      const s = p.front ? 'front' : 'back';
-      if (side !== null && s !== side) {
-        segs[side].push(run);
-        run = [];
-      }
-      run.push(p);
-      side = s;
-    }
-    if (run.length) segs[side].push(run);
-    return segs;
-  };
+  const { project, halves } = makeSphereProjector({ cx, cy, R, viewDeg: 40 });
+  const road = tiltedCircle(EPS);
+  const equatorPt = (t) => project(flatCircle(t));
+  const eclipticPt = (t) => project(road(t));
   const draw = (segs, color, width) =>
-    ['back', 'front'].map((side) =>
-      segs[side].map((seg, i) => (
-        <polyline
-          key={`${side}${i}`}
-          points={seg.map((p) => `${p.X.toFixed(1)},${p.Y.toFixed(1)}`).join(' ')}
-          fill="none"
-          stroke={color}
-          strokeWidth={width}
-          strokeOpacity={side === 'front' ? 0.9 : 0.28}
-          strokeDasharray={side === 'front' ? undefined : '3 3'}
-        />
-      )),
-    );
+    circleHalvesProps(segs, color, width).map((p) => <polyline {...p} />);
 
   // The moving point, and its meridian arc down to the equator — the
   // declination made visible as an arc on the sphere itself.
@@ -236,8 +203,8 @@ function Sphere({ longitude, tilt }) {
       >
         <circle cx={cx} cy={cy} r={R} fill="var(--color-card)" fillOpacity="0.5" stroke="var(--color-border)" strokeWidth="1" />
 
-        {draw(halves(equatorPt), 'var(--color-silver)', 1.5)}
-        {draw(halves(eclipticPt), 'var(--color-gold)', 1.5)}
+        {draw(halves(flatCircle), 'var(--color-silver)', 1.5)}
+        {draw(halves(road), 'var(--color-gold)', 1.5)}
 
         {/* the two crossings */}
         {[

--- a/src/components/book/interactives/MoladLadder.jsx
+++ b/src/components/book/interactives/MoladLadder.jsx
@@ -14,7 +14,7 @@
  */
 import React, { useState } from 'react';
 import InteractiveCard, { PresetButton } from '../../text/interactives/InteractiveCard';
-import { moladTishrei } from '../../../lib/fixedYear';
+import { moladTishrei, moladTishreiLadder } from '../../../lib/fixedYear';
 
 const DAY_NAMES = ['—', 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Shabbat'];
 
@@ -26,9 +26,12 @@ const REMAINDERS = [
   { label: 'a 19-year cycle', triple: '2 – 16 – 595', ref: 'KH 6:12', note: 'twelve common + seven leap years' },
 ];
 
+const t = (x) => `${x.day} – ${x.hours} – ${x.parts}`;
+
 export default function MoladLadder() {
   const [year, setYear] = useState(5786);
   const molad = moladTishrei(year);
+  const ladder = moladTishreiLadder(year);
 
   return (
     <InteractiveCard
@@ -110,12 +113,53 @@ export default function MoladLadder() {
         </PresetButton>
       </div>
       <div className="mt-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-3">
-        <div className="font-mono text-lg font-bold text-[var(--color-gold)]">
+        <div className="text-xs font-bold text-[var(--color-text-secondary)]">
+          The whole ladder, climbed for Tishrei {year} (KH 6:12-14)
+        </div>
+        <div className="mt-2 overflow-x-auto">
+          <table className="w-full min-w-[420px] font-mono text-xs">
+            <thead>
+              <tr className="border-b border-[var(--color-border)] text-left text-[var(--color-text-secondary)]">
+                <th className="py-1 pr-3 font-bold">step</th>
+                <th className="py-1 pr-3 font-bold">adds</th>
+                <th className="py-1 font-bold">running total</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-[var(--color-border)]/40">
+                <td className="py-1 pr-3">
+                  start at the anchor <span className="hebrew-text">בהר"ד</span>
+                </td>
+                <td className="py-1 pr-3 text-[var(--color-text-secondary)]">—</td>
+                <td className="py-1">{t(ladder.anchor)}</td>
+              </tr>
+              {ladder.steps.map((s) => (
+                <tr key={s.label} className="border-b border-[var(--color-border)]/40">
+                  <td className="py-1 pr-3">
+                    + {s.count} {s.label} × {t(s.each)}
+                  </td>
+                  <td className="py-1 pr-3 text-[var(--color-text-secondary)]">{t(s.add)}</td>
+                  <td className="py-1">{t(s.running)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="mt-2 border-t border-[var(--color-border)] pt-2 font-mono text-lg font-bold text-[var(--color-gold)]">
           {DAY_NAMES[molad.day]}, {molad.hours}h {molad.parts}p
         </div>
-        <div className="text-[11px] text-[var(--color-text-secondary)]">
-          = BaHaRaD + (months from year 1 to Tishrei {year}) × 1 – 12 – 793, whole weeks thrown
-          away. Chapter 7 turns this into the day Rosh HaShanah actually falls.
+        <div className="mt-1 text-[11px] leading-relaxed text-[var(--color-text-secondary)]">
+          Year {year} sits {ladder.remainderYears === 0 ? 'exactly at the start of' : `${ladder.remainderYears} year${ladder.remainderYears === 1 ? '' : 's'} into`}{' '}
+          cycle {ladder.cycles + 1}
+          {ladder.remainderYears > 0 && (
+            <>
+              ; of those, {ladder.leapYears === 0 ? 'none are' : ladder.leapYears === 1 ? `position ${ladder.leapPositions[0]} is` : `positions ${ladder.leapPositions.join(', ')} are`}{' '}
+              leap (KH 6:11's seven: 3, 6, 8, 11, 14, 17, 19)
+            </>
+          )}
+          . Each "adds" column is count × remainder with whole weeks already thrown away — every
+          multiplication is just repeated addition mod the week, checkable by hand. Chapter 7 turns
+          the final triple into the day Rosh HaShanah actually falls.
         </div>
       </div>
     </InteractiveCard>

--- a/src/components/book/interactives/ParallaxBySign.jsx
+++ b/src/components/book/interactives/ParallaxBySign.jsx
@@ -276,6 +276,11 @@ function ParallaxSplit({ index, north }) {
         size in every sign — 56′ to 61′, the moon's own parallax showing through — and the sign
         only decides how it splits against the belt's slant. Steep belt: nearly all of it lands
         along the belt, off the gap. Shallow belt: most of it lands across, onto the height.
+        <br />
+        <em>Whose picture is this?</em> He gives only the two tables. The triangle is our
+        reconstruction of the why — he says himself that the reasons behind these numbers belong
+        to "the wisdom of astronomy and geometry, concerning which the Greeks wrote many books"
+        (KH 17:24), and leaves them there.
       </figcaption>
     </figure>
   );

--- a/src/components/book/interactives/ParallaxBySign.jsx
+++ b/src/components/book/interactives/ParallaxBySign.jsx
@@ -258,18 +258,39 @@ function ParallaxSplit({ index, north }) {
           where it is seen — {whole.toFixed(0)}′ away
         </text>
 
-        <text
-          x={(mx + A.x) / 2 - 8}
-          y={(my + A.y) / 2}
-          fontSize="9"
-          textAnchor="end"
-          fill="var(--color-accent)"
-        >
-          along the belt: {lon === 60 ? "1° 0" : lon}′ off the gap
-        </text>
-        <text x={(A.x + D.x) / 2 + 8} y={(A.y + D.y) / 2 + 3} fontSize="9" fill="var(--color-gold)">
-          across it: {lat}′ onto the height ({north ? 'north tonight, so off' : 'south tonight, so on'})
-        </text>
+        {/* The three measurements live in a fixed legend, not floated on
+            the geometry: at steep or shallow slants the components get
+            short and floated labels landed on top of each other. */}
+        {[
+          {
+            stroke: 'var(--color-silver)', dash: '4 3', width: 1.5,
+            text: `the whole shift: ${whole.toFixed(0)}′`, color: 'var(--color-text-secondary)',
+          },
+          {
+            stroke: 'var(--color-accent)', dash: undefined, width: 2.5,
+            text: `along the belt — off the gap: ${lon === 60 ? '1° 0' : lon}′`, color: 'var(--color-accent)',
+          },
+          {
+            stroke: 'var(--color-gold)', dash: undefined, width: 2.5,
+            text: `across it — onto the height: ${lat}′ (${north ? 'north tonight, so off' : 'south tonight, so on'})`,
+            color: 'var(--color-gold)',
+          },
+        ].map((row, i) => (
+          <g key={row.text}>
+            <line
+              x1="10"
+              y1={18 + i * 15}
+              x2="30"
+              y2={18 + i * 15}
+              stroke={row.stroke}
+              strokeWidth={row.width}
+              strokeDasharray={row.dash}
+            />
+            <text x="35" y={21 + i * 15} fontSize="9" fill={row.color}>
+              {row.text}
+            </text>
+          </g>
+        ))}
       </svg>
       <figcaption className="mt-1 text-center text-[11px] text-[var(--color-text-secondary)]">
         The two tables are one triangle. The dashed shift toward the horizon is nearly the same

--- a/src/components/book/interactives/ParallaxBySign.jsx
+++ b/src/components/book/interactives/ParallaxBySign.jsx
@@ -138,7 +138,6 @@ export default function ParallaxBySign() {
       </p>
 
       <Curves index={index} />
-      <ParallaxSplit index={index} north={north} />
 
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
         <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-3">
@@ -173,7 +172,11 @@ export default function ParallaxBySign() {
         circle, and they run in opposite phase — where one is largest the other is smallest. That
         is what you would expect if they are the sideways and the vertical parts of one change in
         appearance, divided differently as the belt tilts against the horizon. They are not twelve
-        unrelated numbers apiece.
+        unrelated numbers apiece. In fact, combine any sign's pair the way the sides of a
+        right-angled triangle combine and the total comes out almost the same in every sign —
+        between 56′ and 61′, which is the moon's own parallax showing through his two tables.
+        (That observation is this book's, not his: he gives the tables and says the reasons
+        belong to the geometry books, KH 17:24.)
       </p>
       <p className="mt-2 text-[11px] leading-relaxed text-[var(--color-text-secondary)]">
         On the evening the Rambam works, the moon is in <strong>Shor</strong> — a full degree off
@@ -186,88 +189,6 @@ export default function ParallaxBySign() {
 /** √(lon² + lat²) for a sign — the whole shift the two tables split. */
 export function wholeShiftArcmin(index) {
   return Math.hypot(LON[index].chalakim, LAT[index].chalakim);
-}
-
-/**
- * The mechanism, told as plainly as it can be told: you see the moon a
- * little away from where it really is, and the two tables are the
- * sideways part and the downward part of that one push. Two moons, one
- * dashed push, one right angle — no belt, no slant, no legend. Earlier
- * drafts drew the true triangle against the belt's direction and a
- * reader could not tell what they were looking at; the split here is
- * schematic (screen-sideways and screen-down), which the caption says.
- *
- * The one discovered fact stays: the whole push is nearly the same
- * size in every sign — 56'-61', the moon's own parallax showing
- * through his two tables — and the sign only re-divides it.
- */
-function ParallaxSplit({ index, north }) {
-  const w = 520;
-  const h = 195;
-  const lon = LON[index].chalakim;
-  const lat = LAT[index].chalakim;
-  const whole = wholeShiftArcmin(index);
-  const s = 1.3; // px per arcminute
-  const trueX = 340;
-  const trueY = 48;
-  const cornerX = trueX - lon * s;
-  const seenY = trueY + lat * s;
-  const horizonY = h - 22;
-
-  return (
-    <figure className="mt-3">
-      <svg
-        viewBox={`0 0 ${w} ${h}`}
-        className="w-full"
-        role="img"
-        aria-label="The moon drawn twice: where it really is, and slightly lower toward the horizon where the eye sees it. The push between them is split into a sideways arrow, the first table, and a downward arrow, the second table."
-      >
-        <line x1="0" y1={horizonY} x2={w} y2={horizonY} stroke="var(--color-border)" strokeWidth="1.5" />
-        <text x="6" y={horizonY + 13} fontSize="8" fill="var(--color-text-secondary)">
-          the horizon
-        </text>
-
-        {/* the whole push, really here → seen here */}
-        <line x1={trueX} y1={trueY} x2={cornerX} y2={seenY} stroke="var(--color-silver)" strokeWidth="1.5" strokeDasharray="4 3" />
-
-        {/* its two parts, at a right angle */}
-        <line x1={trueX} y1={trueY} x2={cornerX} y2={trueY} stroke="var(--color-accent)" strokeWidth="2.5" />
-        <text x={(trueX + cornerX) / 2} y={trueY - 8} fontSize="9" textAnchor="middle" fill="var(--color-accent)">
-          the sideways part: {lon === 60 ? "1° 0" : lon}′ — the first table
-        </text>
-        <line x1={cornerX} y1={trueY} x2={cornerX} y2={seenY} stroke="var(--color-gold)" strokeWidth="2.5" />
-        <text x={cornerX - 8} y={(trueY + seenY) / 2 + 3} fontSize="9" textAnchor="end" fill="var(--color-gold)">
-          the downward part: {lat}′ — the second table
-        </text>
-
-        {/* the two moons */}
-        <circle cx={trueX} cy={trueY} r="9" fill="none" stroke="var(--color-silver)" strokeWidth="1.5" strokeDasharray="2 2" />
-        <text x={trueX + 14} y={trueY + 3} fontSize="9" fill="var(--color-text)">
-          the moon is really here
-        </text>
-        <circle cx={cornerX} cy={seenY} r="9" fill="var(--color-silver)" fillOpacity="0.9" />
-        <text x={cornerX + 14} y={seenY + 3} fontSize="9" fill="var(--color-text)">
-          your eye sees it here
-        </text>
-        <text x={cornerX + 14} y={seenY + 16} fontSize="9" fill="var(--color-text-secondary)">
-          the whole push: {whole.toFixed(0)}′
-        </text>
-      </svg>
-      <figcaption className="mt-1 text-center text-[11px] text-[var(--color-text-secondary)]">
-        You never see the moon quite where it is: you stand on the earth's surface, not at its
-        centre, and that pushes the moon you see about two moon-widths toward the horizon. The two
-        tables are just the two parts of that one push — the first its sideways part, the second
-        its downward part — and the sign decides the split, never the size: the whole push stays
-        56′–61′ in every sign. (The directions here are schematic — "sideways" runs along the
-        sun's road.)
-        <br />
-        <em>Whose picture is this?</em> He gives only the two tables. The push-and-parts is our
-        reconstruction of the why — he says himself that the reasons behind these numbers belong
-        to "the wisdom of astronomy and geometry, concerning which the Greeks wrote many books"
-        (KH 17:24), and leaves them there.
-      </figcaption>
-    </figure>
-  );
 }
 
 function Curves({ index }) {

--- a/src/components/book/interactives/ParallaxBySign.jsx
+++ b/src/components/book/interactives/ParallaxBySign.jsx
@@ -134,7 +134,9 @@ export default function ParallaxBySign() {
         </strong>{' '}
         sign, where sighting nights fall in {SIGHTING_MONTHS[index]} — and sits{' '}
         <strong className="font-mono">{formatDms(Math.abs(night.latitude))}</strong>{' '}
-        <strong>{north ? 'north' : 'south'}</strong> of the road. Both computed, neither chosen: the sign comes from chapter 15's calculation of where the moon stands, and north-or-south from chapter 16's calculation of its height off the road.
+        <strong>{north ? 'north' : 'south'}</strong> of the road. You don't pick these two facts,
+        and you couldn't — the calculation produces them: chapter 15 says where the moon stands
+        (so, its sign), and chapter 16 says whether it sits north or south of the road.
       </p>
 
       <Curves index={index} />

--- a/src/components/book/interactives/ParallaxBySign.jsx
+++ b/src/components/book/interactives/ParallaxBySign.jsx
@@ -189,34 +189,29 @@ export function wholeShiftArcmin(index) {
 }
 
 /**
- * The mechanism the two curves only hint at, drawn as the triangle it
- * is. The whole change in appearance is one shift of nearly constant
- * size — √(lon² + lat²) stays within 56′–61′ across all twelve signs,
- * which is the moon's own parallax showing through his tables — and
- * what varies by sign is only how it SPLITS against the belt's slant:
- * along the belt (off the gap) and across it (onto the height). The
- * belt's drawn slant is derived from the two table values themselves,
- * so the figure asserts nothing the tables don't say.
+ * The mechanism, told as plainly as it can be told: you see the moon a
+ * little away from where it really is, and the two tables are the
+ * sideways part and the downward part of that one push. Two moons, one
+ * dashed push, one right angle — no belt, no slant, no legend. Earlier
+ * drafts drew the true triangle against the belt's direction and a
+ * reader could not tell what they were looking at; the split here is
+ * schematic (screen-sideways and screen-down), which the caption says.
+ *
+ * The one discovered fact stays: the whole push is nearly the same
+ * size in every sign — 56'-61', the moon's own parallax showing
+ * through his two tables — and the sign only re-divides it.
  */
 function ParallaxSplit({ index, north }) {
   const w = 520;
-  const h = 200;
+  const h = 195;
   const lon = LON[index].chalakim;
   const lat = LAT[index].chalakim;
   const whole = wholeShiftArcmin(index);
-  const scale = 1.7; // px per arcminute
-  const mx = 330;
-  const my = 28;
-  // The whole shift points straight down (toward the horizon). The
-  // along-belt component leaves it at α, where cos α = lon / whole —
-  // small α means a steep belt taking nearly the whole shift sideways
-  // along itself.
-  const alpha = Math.acos(lon / whole);
-  const beltDir = { x: -Math.sin(alpha), y: Math.cos(alpha) };
-  const A = { x: mx + beltDir.x * lon * scale, y: my + beltDir.y * lon * scale };
-  const D = { x: mx, y: my + whole * scale };
-  const beltFrom = { x: mx - beltDir.x * 34, y: my - beltDir.y * 34 };
-  const beltTo = { x: mx + beltDir.x * (lon * scale + 40), y: my + beltDir.y * (lon * scale + 40) };
+  const s = 1.3; // px per arcminute
+  const trueX = 340;
+  const trueY = 48;
+  const cornerX = trueX - lon * s;
+  const seenY = trueY + lat * s;
   const horizonY = h - 22;
 
   return (
@@ -225,80 +220,48 @@ function ParallaxSplit({ index, north }) {
         viewBox={`0 0 ${w} ${h}`}
         className="w-full"
         role="img"
-        aria-label="One shift of nearly constant size, pointing toward the horizon, split into a component along the belt and a component across it; the split follows the belt's slant for the chosen sign"
+        aria-label="The moon drawn twice: where it really is, and slightly lower toward the horizon where the eye sees it. The push between them is split into a sideways arrow, the first table, and a downward arrow, the second table."
       >
         <line x1="0" y1={horizonY} x2={w} y2={horizonY} stroke="var(--color-border)" strokeWidth="1.5" />
         <text x="6" y={horizonY + 13} fontSize="8" fill="var(--color-text-secondary)">
-          toward the horizon
+          the horizon
         </text>
 
-        {/* the belt through the moon, at the slant the two values imply */}
-        <line x1={beltFrom.x} y1={beltFrom.y} x2={beltTo.x} y2={beltTo.y} stroke="var(--color-gold)" strokeWidth="1" strokeOpacity="0.45" />
-        <text
-          x={beltTo.x + 4}
-          y={beltTo.y + 4}
-          fontSize="8"
-          fill="var(--color-gold)"
-          fillOpacity="0.8"
-        >
-          the belt
+        {/* the whole push, really here → seen here */}
+        <line x1={trueX} y1={trueY} x2={cornerX} y2={seenY} stroke="var(--color-silver)" strokeWidth="1.5" strokeDasharray="4 3" />
+
+        {/* its two parts, at a right angle */}
+        <line x1={trueX} y1={trueY} x2={cornerX} y2={trueY} stroke="var(--color-accent)" strokeWidth="2.5" />
+        <text x={(trueX + cornerX) / 2} y={trueY - 8} fontSize="9" textAnchor="middle" fill="var(--color-accent)">
+          the sideways part: {lon === 60 ? "1° 0" : lon}′ — the first table
+        </text>
+        <line x1={cornerX} y1={trueY} x2={cornerX} y2={seenY} stroke="var(--color-gold)" strokeWidth="2.5" />
+        <text x={cornerX - 8} y={(trueY + seenY) / 2 + 3} fontSize="9" textAnchor="end" fill="var(--color-gold)">
+          the downward part: {lat}′ — the second table
         </text>
 
-        {/* the whole shift, and its two parts */}
-        <line x1={mx} y1={my} x2={D.x} y2={D.y} stroke="var(--color-silver)" strokeWidth="1.5" strokeDasharray="4 3" />
-        <line x1={mx} y1={my} x2={A.x} y2={A.y} stroke="var(--color-accent)" strokeWidth="2.5" />
-        <line x1={A.x} y1={A.y} x2={D.x} y2={D.y} stroke="var(--color-gold)" strokeWidth="2.5" />
-
-        <circle cx={mx} cy={my} r="5" fill="var(--color-silver)" stroke="var(--color-bg)" strokeWidth="1.5" />
-        <text x={mx + 10} y={my + 3} fontSize="9" fill="var(--color-text)">
-          the moon, where it truly is
+        {/* the two moons */}
+        <circle cx={trueX} cy={trueY} r="9" fill="none" stroke="var(--color-silver)" strokeWidth="1.5" strokeDasharray="2 2" />
+        <text x={trueX + 14} y={trueY + 3} fontSize="9" fill="var(--color-text)">
+          the moon is really here
         </text>
-        <circle cx={D.x} cy={D.y} r="3.5" fill="var(--color-silver)" fillOpacity="0.7" />
-        <text x={D.x + 8} y={D.y + 3} fontSize="9" fill="var(--color-text-secondary)">
-          where it is seen — {whole.toFixed(0)}′ away
+        <circle cx={cornerX} cy={seenY} r="9" fill="var(--color-silver)" fillOpacity="0.9" />
+        <text x={cornerX + 14} y={seenY + 3} fontSize="9" fill="var(--color-text)">
+          your eye sees it here
         </text>
-
-        {/* The three measurements live in a fixed legend, not floated on
-            the geometry: at steep or shallow slants the components get
-            short and floated labels landed on top of each other. */}
-        {[
-          {
-            stroke: 'var(--color-silver)', dash: '4 3', width: 1.5,
-            text: `the whole shift: ${whole.toFixed(0)}′`, color: 'var(--color-text-secondary)',
-          },
-          {
-            stroke: 'var(--color-accent)', dash: undefined, width: 2.5,
-            text: `along the belt — off the gap: ${lon === 60 ? '1° 0' : lon}′`, color: 'var(--color-accent)',
-          },
-          {
-            stroke: 'var(--color-gold)', dash: undefined, width: 2.5,
-            text: `across it — onto the height: ${lat}′ (${north ? 'north tonight, so off' : 'south tonight, so on'})`,
-            color: 'var(--color-gold)',
-          },
-        ].map((row, i) => (
-          <g key={row.text}>
-            <line
-              x1="10"
-              y1={18 + i * 15}
-              x2="30"
-              y2={18 + i * 15}
-              stroke={row.stroke}
-              strokeWidth={row.width}
-              strokeDasharray={row.dash}
-            />
-            <text x="35" y={21 + i * 15} fontSize="9" fill={row.color}>
-              {row.text}
-            </text>
-          </g>
-        ))}
+        <text x={cornerX + 14} y={seenY + 16} fontSize="9" fill="var(--color-text-secondary)">
+          the whole push: {whole.toFixed(0)}′
+        </text>
       </svg>
       <figcaption className="mt-1 text-center text-[11px] text-[var(--color-text-secondary)]">
-        The two tables are one triangle. The dashed shift toward the horizon is nearly the same
-        size in every sign — 56′ to 61′, the moon's own parallax showing through — and the sign
-        only decides how it splits against the belt's slant. Steep belt: nearly all of it lands
-        along the belt, off the gap. Shallow belt: most of it lands across, onto the height.
+        You never see the moon quite where it is: you stand on the earth's surface, not at its
+        centre, and that pushes the moon you see about two moon-widths toward the horizon. The two
+        tables are just the two parts of that one push — the first its sideways part, the second
+        its downward part — and the sign decides the split, never the size: the whole push stays
+        56′–61′ in every sign. (The directions here are schematic — "sideways" runs along the
+        sun's road.)
         <br />
-        <em>Whose picture is this?</em> He gives only the two tables. The triangle is our
+        <em>Whose picture is this?</em> He gives only the two tables. The push-and-parts is our
         reconstruction of the why — he says himself that the reasons behind these numbers belong
         to "the wisdom of astronomy and geometry, concerning which the Greeks wrote many books"
         (KH 17:24), and leaves them there.

--- a/src/components/book/interactives/ParallaxBySign.jsx
+++ b/src/components/book/interactives/ParallaxBySign.jsx
@@ -138,6 +138,7 @@ export default function ParallaxBySign() {
       </p>
 
       <Curves index={index} />
+      <ParallaxSplit index={index} north={north} />
 
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
         <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-3">
@@ -179,6 +180,104 @@ export default function ParallaxBySign() {
         the gap, the largest of the twelve, and ten minutes onto the height.
       </p>
     </InteractiveCard>
+  );
+}
+
+/** √(lon² + lat²) for a sign — the whole shift the two tables split. */
+export function wholeShiftArcmin(index) {
+  return Math.hypot(LON[index].chalakim, LAT[index].chalakim);
+}
+
+/**
+ * The mechanism the two curves only hint at, drawn as the triangle it
+ * is. The whole change in appearance is one shift of nearly constant
+ * size — √(lon² + lat²) stays within 56′–61′ across all twelve signs,
+ * which is the moon's own parallax showing through his tables — and
+ * what varies by sign is only how it SPLITS against the belt's slant:
+ * along the belt (off the gap) and across it (onto the height). The
+ * belt's drawn slant is derived from the two table values themselves,
+ * so the figure asserts nothing the tables don't say.
+ */
+function ParallaxSplit({ index, north }) {
+  const w = 520;
+  const h = 200;
+  const lon = LON[index].chalakim;
+  const lat = LAT[index].chalakim;
+  const whole = wholeShiftArcmin(index);
+  const scale = 1.7; // px per arcminute
+  const mx = 330;
+  const my = 28;
+  // The whole shift points straight down (toward the horizon). The
+  // along-belt component leaves it at α, where cos α = lon / whole —
+  // small α means a steep belt taking nearly the whole shift sideways
+  // along itself.
+  const alpha = Math.acos(lon / whole);
+  const beltDir = { x: -Math.sin(alpha), y: Math.cos(alpha) };
+  const A = { x: mx + beltDir.x * lon * scale, y: my + beltDir.y * lon * scale };
+  const D = { x: mx, y: my + whole * scale };
+  const beltFrom = { x: mx - beltDir.x * 34, y: my - beltDir.y * 34 };
+  const beltTo = { x: mx + beltDir.x * (lon * scale + 40), y: my + beltDir.y * (lon * scale + 40) };
+  const horizonY = h - 22;
+
+  return (
+    <figure className="mt-3">
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        className="w-full"
+        role="img"
+        aria-label="One shift of nearly constant size, pointing toward the horizon, split into a component along the belt and a component across it; the split follows the belt's slant for the chosen sign"
+      >
+        <line x1="0" y1={horizonY} x2={w} y2={horizonY} stroke="var(--color-border)" strokeWidth="1.5" />
+        <text x="6" y={horizonY + 13} fontSize="8" fill="var(--color-text-secondary)">
+          toward the horizon
+        </text>
+
+        {/* the belt through the moon, at the slant the two values imply */}
+        <line x1={beltFrom.x} y1={beltFrom.y} x2={beltTo.x} y2={beltTo.y} stroke="var(--color-gold)" strokeWidth="1" strokeOpacity="0.45" />
+        <text
+          x={beltTo.x + 4}
+          y={beltTo.y + 4}
+          fontSize="8"
+          fill="var(--color-gold)"
+          fillOpacity="0.8"
+        >
+          the belt
+        </text>
+
+        {/* the whole shift, and its two parts */}
+        <line x1={mx} y1={my} x2={D.x} y2={D.y} stroke="var(--color-silver)" strokeWidth="1.5" strokeDasharray="4 3" />
+        <line x1={mx} y1={my} x2={A.x} y2={A.y} stroke="var(--color-accent)" strokeWidth="2.5" />
+        <line x1={A.x} y1={A.y} x2={D.x} y2={D.y} stroke="var(--color-gold)" strokeWidth="2.5" />
+
+        <circle cx={mx} cy={my} r="5" fill="var(--color-silver)" stroke="var(--color-bg)" strokeWidth="1.5" />
+        <text x={mx + 10} y={my + 3} fontSize="9" fill="var(--color-text)">
+          the moon, where it truly is
+        </text>
+        <circle cx={D.x} cy={D.y} r="3.5" fill="var(--color-silver)" fillOpacity="0.7" />
+        <text x={D.x + 8} y={D.y + 3} fontSize="9" fill="var(--color-text-secondary)">
+          where it is seen — {whole.toFixed(0)}′ away
+        </text>
+
+        <text
+          x={(mx + A.x) / 2 - 8}
+          y={(my + A.y) / 2}
+          fontSize="9"
+          textAnchor="end"
+          fill="var(--color-accent)"
+        >
+          along the belt: {lon === 60 ? "1° 0" : lon}′ off the gap
+        </text>
+        <text x={(A.x + D.x) / 2 + 8} y={(A.y + D.y) / 2 + 3} fontSize="9" fill="var(--color-gold)">
+          across it: {lat}′ onto the height ({north ? 'north tonight, so off' : 'south tonight, so on'})
+        </text>
+      </svg>
+      <figcaption className="mt-1 text-center text-[11px] text-[var(--color-text-secondary)]">
+        The two tables are one triangle. The dashed shift toward the horizon is nearly the same
+        size in every sign — 56′ to 61′, the moon's own parallax showing through — and the sign
+        only decides how it splits against the belt's slant. Steep belt: nearly all of it lands
+        along the belt, off the gap. Shallow belt: most of it lands across, onto the height.
+      </figcaption>
+    </figure>
   );
 }
 

--- a/src/components/book/interactives/QuickVerdict.jsx
+++ b/src/components/book/interactives/QuickVerdict.jsx
@@ -18,10 +18,13 @@
  * one is used.
  */
 import React, { useState } from 'react';
-import InteractiveCard from '../../text/interactives/InteractiveCard';
+import InteractiveCard, { PresetButton } from '../../text/interactives/InteractiveCard';
 import { CONSTANTS } from '../../../engine/constants';
 import { formatDms } from '../../../engine/dmsUtils';
 import { zodiacPosition } from '../../../engine/zodiac';
+import { getFullCalculation } from '../../../engine/pipeline';
+import { dateFromEpochDays, daysFromEpoch } from '../../../engine/epochDays';
+import { nextSightingNight } from '../../../lib/sightingNight';
 
 const { capricornGemini, cancerSagittarius } = CONSTANTS.EARLY_EXIT_THRESHOLDS;
 
@@ -35,14 +38,50 @@ function halfFor(moonLongitude) {
     : { ...cancerSagittarius, name: 'Sartan through Keshet', id: 'cs' };
 }
 
+/** Tonight = the evening beginning the NEXT Hebrew day (see SkyPage). */
+function tonightDays() {
+  const now = new Date();
+  return daysFromEpoch(new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12)) + 1;
+}
+
 export default function QuickVerdict() {
-  // His worked evening: moon at 48°36' (Shor), first longitude 11°27'.
-  const [moonLongitude, setMoonLongitude] = useState(48.6);
-  const [orech, setOrech] = useState(11.45);
+  // His worked evening (day 29): moon ~48°36' (Shor), first longitude
+  // ~11°27' — but taken FROM the engine, not typed in, since the card
+  // presents them as computed.
+  const [example] = useState(() => {
+    const calc = getFullCalculation(dateFromEpochDays(29));
+    return {
+      lon: ((calc.moon.trueLongitude % 360) + 360) % 360,
+      gap: calc.moon.elongation,
+    };
+  });
+  const [moonLongitude, setMoonLongitude] = useState(example.lon);
+  const [orech, setOrech] = useState(example.gap);
+  // The night the sliders were computed FROM — null once a slider is
+  // moved by hand, so the card never claims engine authority for a
+  // hand-set number.
+  const [nightDays, setNightDays] = useState(29);
+
+  // The calculator: both inputs from the engine for a chosen night —
+  // the moon's true place (ch. 15) and the first longitude (KH 17:1).
+  const applyNight = (d) => {
+    const calc = getFullCalculation(dateFromEpochDays(d));
+    setMoonLongitude(((calc.moon.trueLongitude % 360) + 360) % 360);
+    setOrech(calc.moon.elongation);
+    setNightDays(d);
+  };
+  const byHand = (setter) => (e) => {
+    setter(Number(e.target.value));
+    setNightDays(null);
+  };
+  const eve = nightDays != null ? new Date(dateFromEpochDays(nightDays) - 86400000) : null;
 
   const half = halfFor(moonLongitude);
   const sign = zodiacPosition(moonLongitude);
 
+  // A crescent question needs the moon AHEAD of the sun and near it.
+  const noCrescent = orech > 180;
+  const offChart = !noCrescent && orech > 30;
   const settled =
     orech <= half.invisibleMax ? 'not-seen' : orech > half.visibleMin ? 'seen' : 'undecided';
 
@@ -53,7 +92,33 @@ export default function QuickVerdict() {
       blurb="two thresholds on the gap alone — and they differ by half the sky"
       defaultOpen
     >
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-bold text-[var(--color-text-secondary)]">
+          Compute a real night:
+        </span>
+        <PresetButton onClick={() => applyNight(29)} title="2 Iyar 4938 — the evening KH 17 works through">
+          His example (29)
+        </PresetButton>
+        <PresetButton
+          onClick={() => applyNight(nextSightingNight().days)}
+          title="The evening after the 29th — the night the court would look"
+        >
+          Next Rosh Chodesh
+        </PresetButton>
+        <PresetButton onClick={() => applyNight(tonightDays())}>Tonight</PresetButton>
+      </div>
+      <p className="mt-1 text-[11px] text-[var(--color-text-secondary)]">
+        {nightDays != null ? (
+          <>
+            The night of <strong>{eve.toISOString().slice(0, 10)}</strong> — both numbers below
+            computed by the engine: the moon's place from chapter 15, the gap from KH 17:1.
+          </>
+        ) : (
+          <>Set by hand — slide freely; the presets above return to a computed night.</>
+        )}
+      </p>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
         <label className="block">
           <span className="text-xs font-bold text-[var(--color-text-secondary)]">
             Where the moon is — {sign.translit} {formatDms(sign.degreesInto)}
@@ -64,7 +129,7 @@ export default function QuickVerdict() {
             max="359"
             step="1"
             value={moonLongitude}
-            onChange={(e) => setMoonLongitude(Number(e.target.value))}
+            onChange={byHand(setMoonLongitude)}
             className="mt-1 w-full accent-[var(--color-silver)]"
             aria-label="The moon's position in degrees"
           />
@@ -78,8 +143,8 @@ export default function QuickVerdict() {
             min="0"
             max="30"
             step="0.05"
-            value={orech}
-            onChange={(e) => setOrech(Number(e.target.value))}
+            value={Math.min(orech, 30)}
+            onChange={byHand(setOrech)}
             className="mt-1 w-full accent-[var(--color-gold)]"
             aria-label="First longitude in degrees"
           />
@@ -108,20 +173,32 @@ export default function QuickVerdict() {
           {half.invisibleMax}° and {half.visibleMin}° ({half.source})
         </div>
         <div className="mt-1 text-lg font-bold">
-          {settled === 'not-seen' && (
-            <span className="text-[var(--color-text-secondary)]">
-              Settled: cannot be seen
-            </span>
-          )}
-          {settled === 'seen' && <span className="text-[var(--color-accent)]">Settled: will be seen</span>}
-          {settled === 'undecided' && (
-            <span className="text-[var(--color-gold)]">Not settled — the long chain is needed</span>
+          {noCrescent ? (
+            <span className="text-[var(--color-text-secondary)]">No crescent to judge yet</span>
+          ) : (
+            <>
+              {settled === 'not-seen' && (
+                <span className="text-[var(--color-text-secondary)]">
+                  Settled: cannot be seen
+                </span>
+              )}
+              {settled === 'seen' && (
+                <span className="text-[var(--color-accent)]">Settled: will be seen</span>
+              )}
+              {settled === 'undecided' && (
+                <span className="text-[var(--color-gold)]">Not settled — the long chain is needed</span>
+              )}
+            </>
           )}
         </div>
         <div className="mt-0.5 text-[11px] text-[var(--color-text-secondary)]">
-          {settled === 'undecided'
-            ? `Between ${half.invisibleMax}° and ${half.visibleMin}°, so everything from the parallax corrections onward has to be worked out.`
-            : 'No further calculation needed. The Rambam says so in as many words.'}
+          {noCrescent
+            ? `The moon still trails the sun on this night — conjunction has not passed, so the early exit has nothing to rule on. Try the next evening.`
+            : offChart
+              ? `The gap is ${formatDms(orech)} — off this chart's 30° and far past every threshold: a mid-month moon, trivially seen.`
+              : settled === 'undecided'
+                ? `Between ${half.invisibleMax}° and ${half.visibleMin}°, so everything from the parallax corrections onward has to be worked out.`
+                : 'No further calculation needed. The Rambam says so in as many words.'}
         </div>
       </div>
 

--- a/src/components/book/interactives/QuickVerdict.jsx
+++ b/src/components/book/interactives/QuickVerdict.jsx
@@ -23,7 +23,7 @@ import { CONSTANTS } from '../../../engine/constants';
 import { formatDms } from '../../../engine/dmsUtils';
 import { zodiacPosition } from '../../../engine/zodiac';
 import { getFullCalculation } from '../../../engine/pipeline';
-import { dateFromEpochDays, daysFromEpoch } from '../../../engine/epochDays';
+import { dateFromEpochDays } from '../../../engine/epochDays';
 import { nextSightingNight } from '../../../lib/sightingNight';
 
 const { capricornGemini, cancerSagittarius } = CONSTANTS.EARLY_EXIT_THRESHOLDS;
@@ -36,12 +36,6 @@ function halfFor(moonLongitude) {
   return capricornToGemini
     ? { ...capricornGemini, name: "G'di through Teomim", id: 'cg' }
     : { ...cancerSagittarius, name: 'Sartan through Keshet', id: 'cs' };
-}
-
-/** Tonight = the evening beginning the NEXT Hebrew day (see SkyPage). */
-function tonightDays() {
-  const now = new Date();
-  return daysFromEpoch(new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12)) + 1;
 }
 
 export default function QuickVerdict() {
@@ -105,7 +99,6 @@ export default function QuickVerdict() {
         >
           Next Rosh Chodesh
         </PresetButton>
-        <PresetButton onClick={() => applyNight(tonightDays())}>Tonight</PresetButton>
       </div>
       <p className="mt-1 text-[11px] text-[var(--color-text-secondary)]">
         {nightDays != null ? (

--- a/src/components/book/interactives/SliceShape.jsx
+++ b/src/components/book/interactives/SliceShape.jsx
@@ -26,14 +26,6 @@ import React, { useState } from 'react';
 import InteractiveCard from '../../text/interactives/InteractiveCard';
 import { CONSTANTS } from '../../../engine/constants';
 import { ordinalSuffix } from '../../../engine/zodiac';
-import { MAX_TILT } from '../../../lib/khDeclination';
-import {
-  makeSphereProjector,
-  flatCircle,
-  tiltedCircle,
-  circleHalvesProps,
-  GeometryAside,
-} from './sphereProjection';
 
 const BANDS = CONSTANTS.MOON_CIRCLE_FRACTIONS;
 const PEAK = 2 / 5;
@@ -60,167 +52,6 @@ function fractionWords(f) {
   if (f === 1 / 6) return 'a sixth';
   if (f === 1 / 12) return 'a twelfth';
   return 'a twenty-fourth';
-}
-
-const DEG = Math.PI / 180;
-
-/**
- * Why the staircase has the anchors it has, shown on the sphere the
- * fractions come from. The two great circles are chapter 19's pair —
- * the equator and the sun's road — and the annotation is the road's
- * LOCAL DIRECTION: a gold arrow along the road at the moon's spot, a
- * silver arrow along the parallel of the equator through the same spot
- * (the "level" direction). At the crossings the two arrows split by
- * the full 23½°, and the staircase above peaks; at the turning points
- * they merge, the road runs level, and the staircase dies to nothing.
- * The angle between the arrows is computed, not drawn for effect.
- */
-export function roadLevelAngle(lonDeg) {
-  const t = lonDeg * DEG;
-  const eps = MAX_TILT * DEG;
-  // Tangent to the road at t, and to the equator-parallel through the
-  // same point. Both unit up to a common factor; the angle between
-  // them is what "steepest against level" means.
-  const road = [-Math.sin(t), Math.cos(t) * Math.cos(eps), Math.cos(t) * Math.sin(eps)];
-  const level = [-Math.sin(t) * Math.cos(eps), Math.cos(t), 0];
-  const dot = road[0] * level[0] + road[1] * level[1] + road[2] * level[2];
-  const norm = (v) => Math.hypot(v[0], v[1], v[2]);
-  return Math.acos(Math.min(1, Math.max(-1, dot / (norm(road) * norm(level))))) / DEG;
-}
-
-function SliceSphere({ lon }) {
-  const w = 520;
-  const h = 220;
-  const cx = w / 2;
-  const cy = h / 2 + 4;
-  const R = 92;
-  const eps = MAX_TILT * DEG;
-  const { project, halves } = makeSphereProjector({ cx, cy, R, viewDeg: 40 });
-  const road = tiltedCircle(eps);
-
-  const t = lon * DEG;
-  const pt3 = road(t);
-  const moving = project(pt3);
-  // The parallel of the equator through the moon's spot: constant
-  // height above the equator's plane.
-  const z0 = pt3.z;
-  const r0 = Math.sqrt(Math.max(0, 1 - z0 * z0));
-  const parallel = (tp) => ({ x: r0 * Math.cos(tp), y: r0 * Math.sin(tp), z: z0 });
-
-  // The two direction arrows out of the moving point, equal drawn length.
-  const roadDir = [-Math.sin(t), Math.cos(t) * Math.cos(eps), Math.cos(t) * Math.sin(eps)];
-  const levelDir = [-Math.sin(t) * Math.cos(eps), Math.cos(t), 0];
-  const along = (v, len) => {
-    const s = len / Math.hypot(v[0], v[1], v[2]);
-    return project({ x: pt3.x + v[0] * s, y: pt3.y + v[1] * s, z: pt3.z + v[2] * s });
-  };
-  const ARROW = 0.5;
-  const roadTip = along(roadDir, ARROW);
-  const levelTip = along(levelDir, ARROW);
-  const angle = roadLevelAngle(lon);
-  const merged = angle < 6; // arrows lie on top of each other
-  const dim = moving.front ? 1 : 0.45;
-
-  // A wedge between the two directions, so the printed angle visibly
-  // belongs to them: interpolate between the unit tangents.
-  const wedge = [];
-  for (let k = 0; k <= 1.0001; k += 0.1) {
-    const v = [
-      roadDir[0] * (1 - k) + levelDir[0] * k,
-      roadDir[1] * (1 - k) + levelDir[1] * k,
-      roadDir[2] * (1 - k) + levelDir[2] * k,
-    ];
-    wedge.push(along(v, ARROW * 0.55));
-  }
-
-  const draw = (segs, color, width) =>
-    circleHalvesProps(segs, color, width).map((p) => <polyline {...p} />);
-  const taleh = project(flatCircle(0));
-  const moznayim = project(flatCircle(Math.PI));
-  const equatorLabelAt = project(flatCircle(Math.PI / 2));
-  const roadLabelAt = project(road(Math.PI / 2));
-  const label = (tip, txt, color) => (
-    <text
-      x={tip.X + (tip.X >= moving.X ? 5 : -5)}
-      y={tip.Y + 3}
-      fontSize="8.5"
-      textAnchor={tip.X >= moving.X ? 'start' : 'end'}
-      fill={color}
-      fillOpacity={dim}
-    >
-      {txt}
-    </text>
-  );
-
-  return (
-    <figure className="mt-3">
-      <svg
-        viewBox={`0 0 ${w} ${h}`}
-        className="w-full"
-        role="img"
-        aria-label="The equator and the sun's road on a sphere, with two labelled arrows at the moon's spot: one along the road, one along the level ring; the wedge between them is largest at the crossings and vanishes at the turning points, matching the staircase"
-      >
-        <circle cx={cx} cy={cy} r={R} fill="var(--color-card)" fillOpacity="0.5" stroke="var(--color-border)" strokeWidth="1" />
-        {draw(halves(flatCircle), 'var(--color-silver)', 1.25)}
-        {draw(halves(parallel), 'var(--color-silver)', 0.6)}
-        {draw(halves(road), 'var(--color-gold)', 1.5)}
-
-        {/* every line named on the drawing itself */}
-        <text x={equatorLabelAt.X + 4} y={equatorLabelAt.Y + 12} fontSize="9" fill="var(--color-silver)">
-          the equator
-        </text>
-        <text x={roadLabelAt.X + 4} y={roadLabelAt.Y - 6} fontSize="9" fill="var(--color-gold)">
-          the sun's road
-        </text>
-
-        {[
-          { p: taleh, label: 'a crossing — the 1st starts', dx: 7, anchor: 'start' },
-          { p: moznayim, label: 'a crossing — the 7th starts', dx: -7, anchor: 'end' },
-        ].map(({ p, label: txt, dx, anchor }) => (
-          <g key={txt}>
-            <circle cx={p.X} cy={p.Y} r="3" fill="var(--color-accent)" />
-            <text x={p.X + dx} y={p.Y - 4} fontSize="7.5" textAnchor={anchor} fill="var(--color-accent)">
-              {txt}
-            </text>
-          </g>
-        ))}
-
-        {/* the wedge between the two directions, carrying the number */}
-        {!merged && (
-          <polyline
-            points={wedge.map((p) => `${p.X.toFixed(1)},${p.Y.toFixed(1)}`).join(' ')}
-            fill="none"
-            stroke="var(--color-accent)"
-            strokeWidth="1"
-            strokeOpacity={0.8 * dim}
-          />
-        )}
-
-        {/* the two directions out of the moon's spot */}
-        <line x1={moving.X} y1={moving.Y} x2={levelTip.X} y2={levelTip.Y} stroke="var(--color-silver)" strokeWidth="2" strokeOpacity={dim} />
-        <line x1={moving.X} y1={moving.Y} x2={roadTip.X} y2={roadTip.Y} stroke="var(--color-gold)" strokeWidth="2" strokeOpacity={dim} />
-        {label(roadTip, 'where the road goes next', 'var(--color-gold)')}
-        {!merged && label(levelTip, 'level — along its ring', 'var(--color-silver)')}
-
-        <circle cx={moving.X} cy={moving.Y} r="4.5" fill="var(--color-silver)" fillOpacity={dim} stroke="var(--color-bg)" strokeWidth="1.25" />
-        <text x={moving.X} y={moving.Y + 15} fontSize="8.5" textAnchor="middle" fill="var(--color-text)" fillOpacity={dim}>
-          the moon's spot
-        </text>
-        <text x={moving.X} y={moving.Y - 10} fontSize="9.5" fontWeight="bold" textAnchor="middle" fill="var(--color-accent)" fillOpacity={dim}>
-          {merged ? 'the road runs level here' : `${angle.toFixed(0)}° apart`}
-        </text>
-      </svg>
-      <figcaption className="mt-1 text-center text-[11px] text-[var(--color-text-secondary)]">
-        The same slider, on the sphere. The moon's spot rides the gold road; the thin silver ring
-        through it is "level" — no closer to and no further from the equator. The two arrows
-        compare directions: <span className="text-[var(--color-gold)]">where the road goes next</span>{' '}
-        against <span style={{ opacity: 0.8 }}>level along the ring</span>. Their gap is what the
-        staircase plots: the full 23½° at the two crossings, where the slice peaks at two fifths —
-        shrinking to nothing at the turning points, where the road runs level and the slice
-        vanishes.
-      </figcaption>
-    </figure>
-  );
 }
 
 export default function SliceShape() {
@@ -348,10 +179,6 @@ export default function SliceShape() {
           />
         </svg>
       </figure>
-
-      <GeometryAside summary="For the curious: why those anchors — the picture on the sphere">
-        <SliceSphere lon={n} />
-      </GeometryAside>
 
       <label className="mt-2 block">
         <span className="text-xs font-bold text-[var(--color-text-secondary)]">

--- a/src/components/book/interactives/SliceShape.jsx
+++ b/src/components/book/interactives/SliceShape.jsx
@@ -26,6 +26,13 @@ import React, { useState } from 'react';
 import InteractiveCard from '../../text/interactives/InteractiveCard';
 import { CONSTANTS } from '../../../engine/constants';
 import { ordinalSuffix } from '../../../engine/zodiac';
+import { MAX_TILT } from '../../../lib/khDeclination';
+import {
+  makeSphereProjector,
+  flatCircle,
+  tiltedCircle,
+  circleHalvesProps,
+} from './sphereProjection';
 
 const BANDS = CONSTANTS.MOON_CIRCLE_FRACTIONS;
 const PEAK = 2 / 5;
@@ -52,6 +59,109 @@ function fractionWords(f) {
   if (f === 1 / 6) return 'a sixth';
   if (f === 1 / 12) return 'a twelfth';
   return 'a twenty-fourth';
+}
+
+const DEG = Math.PI / 180;
+
+/**
+ * Why the staircase has the anchors it has, shown on the sphere the
+ * fractions come from. The two great circles are chapter 19's pair —
+ * the equator and the sun's road — and the annotation is the road's
+ * LOCAL DIRECTION: a gold arrow along the road at the moon's spot, a
+ * silver arrow along the parallel of the equator through the same spot
+ * (the "level" direction). At the crossings the two arrows split by
+ * the full 23½°, and the staircase above peaks; at the turning points
+ * they merge, the road runs level, and the staircase dies to nothing.
+ * The angle between the arrows is computed, not drawn for effect.
+ */
+export function roadLevelAngle(lonDeg) {
+  const t = lonDeg * DEG;
+  const eps = MAX_TILT * DEG;
+  // Tangent to the road at t, and to the equator-parallel through the
+  // same point. Both unit up to a common factor; the angle between
+  // them is what "steepest against level" means.
+  const road = [-Math.sin(t), Math.cos(t) * Math.cos(eps), Math.cos(t) * Math.sin(eps)];
+  const level = [-Math.sin(t) * Math.cos(eps), Math.cos(t), 0];
+  const dot = road[0] * level[0] + road[1] * level[1] + road[2] * level[2];
+  const norm = (v) => Math.hypot(v[0], v[1], v[2]);
+  return Math.acos(Math.min(1, Math.max(-1, dot / (norm(road) * norm(level))))) / DEG;
+}
+
+function SliceSphere({ lon }) {
+  const w = 520;
+  const h = 220;
+  const cx = w / 2;
+  const cy = h / 2 + 4;
+  const R = 92;
+  const eps = MAX_TILT * DEG;
+  const { project, halves } = makeSphereProjector({ cx, cy, R, viewDeg: 40 });
+  const road = tiltedCircle(eps);
+
+  const t = lon * DEG;
+  const pt3 = road(t);
+  const moving = project(pt3);
+  // The parallel of the equator through the moon's spot: constant
+  // height above the equator's plane.
+  const z0 = pt3.z;
+  const r0 = Math.sqrt(Math.max(0, 1 - z0 * z0));
+  const parallel = (tp) => ({ x: r0 * Math.cos(tp), y: r0 * Math.sin(tp), z: z0 });
+
+  // The two direction arrows out of the moving point, equal drawn length.
+  const arrow = (v) => {
+    const s = 0.42 / Math.hypot(v[0], v[1], v[2]);
+    return project({ x: pt3.x + v[0] * s, y: pt3.y + v[1] * s, z: pt3.z + v[2] * s });
+  };
+  const roadTip = arrow([-Math.sin(t), Math.cos(t) * Math.cos(eps), Math.cos(t) * Math.sin(eps)]);
+  const levelTip = arrow([-Math.sin(t) * Math.cos(eps), Math.cos(t), 0]);
+  const angle = roadLevelAngle(lon);
+  const dim = moving.front ? 1 : 0.45;
+
+  const draw = (segs, color, width) =>
+    circleHalvesProps(segs, color, width).map((p) => <polyline {...p} />);
+  const taleh = project(flatCircle(0));
+  const moznayim = project(flatCircle(Math.PI));
+
+  return (
+    <figure className="mt-3">
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        className="w-full"
+        role="img"
+        aria-label="The equator and the sun's road on a sphere, with two arrows at the moon's spot: one along the road, one along the level parallel; the angle between them is largest at the crossings and vanishes at the turning points, matching the staircase"
+      >
+        <circle cx={cx} cy={cy} r={R} fill="var(--color-card)" fillOpacity="0.5" stroke="var(--color-border)" strokeWidth="1" />
+        {draw(halves(flatCircle), 'var(--color-silver)', 1.25)}
+        {draw(halves(parallel), 'var(--color-silver)', 0.75)}
+        {draw(halves(road), 'var(--color-gold)', 1.5)}
+
+        {[
+          { p: taleh, label: '1st starts', dx: 8, anchor: 'start' },
+          { p: moznayim, label: '7th starts', dx: -8, anchor: 'end' },
+        ].map(({ p, label, dx, anchor }) => (
+          <g key={label}>
+            <circle cx={p.X} cy={p.Y} r="3" fill="var(--color-accent)" />
+            <text x={p.X + dx} y={p.Y + 3} fontSize="8" textAnchor={anchor} fill="var(--color-accent)">
+              {label}
+            </text>
+          </g>
+        ))}
+
+        {/* the two directions out of the moon's spot */}
+        <line x1={moving.X} y1={moving.Y} x2={levelTip.X} y2={levelTip.Y} stroke="var(--color-silver)" strokeWidth="1.5" strokeOpacity={dim} />
+        <line x1={moving.X} y1={moving.Y} x2={roadTip.X} y2={roadTip.Y} stroke="var(--color-gold)" strokeWidth="1.5" strokeOpacity={dim} />
+        <circle cx={moving.X} cy={moving.Y} r="4.5" fill="var(--color-silver)" fillOpacity={dim} stroke="var(--color-bg)" strokeWidth="1.25" />
+        <text x={moving.X} y={moving.Y - 10} fontSize="9" textAnchor="middle" fill="var(--color-text)" fillOpacity={dim}>
+          {angle.toFixed(0)}° apart
+        </text>
+      </svg>
+      <figcaption className="mt-1 text-center text-[11px] text-[var(--color-text-secondary)]">
+        The staircase's anchors, on the sphere it lives on. Gold arrow: the road's direction at the
+        moon's spot. Silver arrow: the level direction — the parallel of the equator through the
+        same spot. They split by the full 23½° at the crossings, where the staircase peaks, and
+        merge at the turning points, where it dies to nothing.
+      </figcaption>
+    </figure>
+  );
 }
 
 export default function SliceShape() {
@@ -179,6 +289,8 @@ export default function SliceShape() {
           />
         </svg>
       </figure>
+
+      <SliceSphere lon={n} />
 
       <label className="mt-2 block">
         <span className="text-xs font-bold text-[var(--color-text-secondary)]">

--- a/src/components/book/interactives/SliceShape.jsx
+++ b/src/components/book/interactives/SliceShape.jsx
@@ -32,6 +32,7 @@ import {
   flatCircle,
   tiltedCircle,
   circleHalvesProps,
+  GeometryAside,
 } from './sphereProjection';
 
 const BANDS = CONSTANTS.MOON_CIRCLE_FRACTIONS;
@@ -107,19 +108,49 @@ function SliceSphere({ lon }) {
   const parallel = (tp) => ({ x: r0 * Math.cos(tp), y: r0 * Math.sin(tp), z: z0 });
 
   // The two direction arrows out of the moving point, equal drawn length.
-  const arrow = (v) => {
-    const s = 0.42 / Math.hypot(v[0], v[1], v[2]);
+  const roadDir = [-Math.sin(t), Math.cos(t) * Math.cos(eps), Math.cos(t) * Math.sin(eps)];
+  const levelDir = [-Math.sin(t) * Math.cos(eps), Math.cos(t), 0];
+  const along = (v, len) => {
+    const s = len / Math.hypot(v[0], v[1], v[2]);
     return project({ x: pt3.x + v[0] * s, y: pt3.y + v[1] * s, z: pt3.z + v[2] * s });
   };
-  const roadTip = arrow([-Math.sin(t), Math.cos(t) * Math.cos(eps), Math.cos(t) * Math.sin(eps)]);
-  const levelTip = arrow([-Math.sin(t) * Math.cos(eps), Math.cos(t), 0]);
+  const ARROW = 0.5;
+  const roadTip = along(roadDir, ARROW);
+  const levelTip = along(levelDir, ARROW);
   const angle = roadLevelAngle(lon);
+  const merged = angle < 6; // arrows lie on top of each other
   const dim = moving.front ? 1 : 0.45;
+
+  // A wedge between the two directions, so the printed angle visibly
+  // belongs to them: interpolate between the unit tangents.
+  const wedge = [];
+  for (let k = 0; k <= 1.0001; k += 0.1) {
+    const v = [
+      roadDir[0] * (1 - k) + levelDir[0] * k,
+      roadDir[1] * (1 - k) + levelDir[1] * k,
+      roadDir[2] * (1 - k) + levelDir[2] * k,
+    ];
+    wedge.push(along(v, ARROW * 0.55));
+  }
 
   const draw = (segs, color, width) =>
     circleHalvesProps(segs, color, width).map((p) => <polyline {...p} />);
   const taleh = project(flatCircle(0));
   const moznayim = project(flatCircle(Math.PI));
+  const equatorLabelAt = project(flatCircle(Math.PI / 2));
+  const roadLabelAt = project(road(Math.PI / 2));
+  const label = (tip, txt, color) => (
+    <text
+      x={tip.X + (tip.X >= moving.X ? 5 : -5)}
+      y={tip.Y + 3}
+      fontSize="8.5"
+      textAnchor={tip.X >= moving.X ? 'start' : 'end'}
+      fill={color}
+      fillOpacity={dim}
+    >
+      {txt}
+    </text>
+  );
 
   return (
     <figure className="mt-3">
@@ -127,38 +158,66 @@ function SliceSphere({ lon }) {
         viewBox={`0 0 ${w} ${h}`}
         className="w-full"
         role="img"
-        aria-label="The equator and the sun's road on a sphere, with two arrows at the moon's spot: one along the road, one along the level parallel; the angle between them is largest at the crossings and vanishes at the turning points, matching the staircase"
+        aria-label="The equator and the sun's road on a sphere, with two labelled arrows at the moon's spot: one along the road, one along the level ring; the wedge between them is largest at the crossings and vanishes at the turning points, matching the staircase"
       >
         <circle cx={cx} cy={cy} r={R} fill="var(--color-card)" fillOpacity="0.5" stroke="var(--color-border)" strokeWidth="1" />
         {draw(halves(flatCircle), 'var(--color-silver)', 1.25)}
-        {draw(halves(parallel), 'var(--color-silver)', 0.75)}
+        {draw(halves(parallel), 'var(--color-silver)', 0.6)}
         {draw(halves(road), 'var(--color-gold)', 1.5)}
 
+        {/* every line named on the drawing itself */}
+        <text x={equatorLabelAt.X + 4} y={equatorLabelAt.Y + 12} fontSize="9" fill="var(--color-silver)">
+          the equator
+        </text>
+        <text x={roadLabelAt.X + 4} y={roadLabelAt.Y - 6} fontSize="9" fill="var(--color-gold)">
+          the sun's road
+        </text>
+
         {[
-          { p: taleh, label: '1st starts', dx: 8, anchor: 'start' },
-          { p: moznayim, label: '7th starts', dx: -8, anchor: 'end' },
-        ].map(({ p, label, dx, anchor }) => (
-          <g key={label}>
+          { p: taleh, label: 'a crossing — the 1st starts', dx: 7, anchor: 'start' },
+          { p: moznayim, label: 'a crossing — the 7th starts', dx: -7, anchor: 'end' },
+        ].map(({ p, label: txt, dx, anchor }) => (
+          <g key={txt}>
             <circle cx={p.X} cy={p.Y} r="3" fill="var(--color-accent)" />
-            <text x={p.X + dx} y={p.Y + 3} fontSize="8" textAnchor={anchor} fill="var(--color-accent)">
-              {label}
+            <text x={p.X + dx} y={p.Y - 4} fontSize="7.5" textAnchor={anchor} fill="var(--color-accent)">
+              {txt}
             </text>
           </g>
         ))}
 
+        {/* the wedge between the two directions, carrying the number */}
+        {!merged && (
+          <polyline
+            points={wedge.map((p) => `${p.X.toFixed(1)},${p.Y.toFixed(1)}`).join(' ')}
+            fill="none"
+            stroke="var(--color-accent)"
+            strokeWidth="1"
+            strokeOpacity={0.8 * dim}
+          />
+        )}
+
         {/* the two directions out of the moon's spot */}
-        <line x1={moving.X} y1={moving.Y} x2={levelTip.X} y2={levelTip.Y} stroke="var(--color-silver)" strokeWidth="1.5" strokeOpacity={dim} />
-        <line x1={moving.X} y1={moving.Y} x2={roadTip.X} y2={roadTip.Y} stroke="var(--color-gold)" strokeWidth="1.5" strokeOpacity={dim} />
+        <line x1={moving.X} y1={moving.Y} x2={levelTip.X} y2={levelTip.Y} stroke="var(--color-silver)" strokeWidth="2" strokeOpacity={dim} />
+        <line x1={moving.X} y1={moving.Y} x2={roadTip.X} y2={roadTip.Y} stroke="var(--color-gold)" strokeWidth="2" strokeOpacity={dim} />
+        {label(roadTip, 'where the road goes next', 'var(--color-gold)')}
+        {!merged && label(levelTip, 'level — along its ring', 'var(--color-silver)')}
+
         <circle cx={moving.X} cy={moving.Y} r="4.5" fill="var(--color-silver)" fillOpacity={dim} stroke="var(--color-bg)" strokeWidth="1.25" />
-        <text x={moving.X} y={moving.Y - 10} fontSize="9" textAnchor="middle" fill="var(--color-text)" fillOpacity={dim}>
-          {angle.toFixed(0)}° apart
+        <text x={moving.X} y={moving.Y + 15} fontSize="8.5" textAnchor="middle" fill="var(--color-text)" fillOpacity={dim}>
+          the moon's spot
+        </text>
+        <text x={moving.X} y={moving.Y - 10} fontSize="9.5" fontWeight="bold" textAnchor="middle" fill="var(--color-accent)" fillOpacity={dim}>
+          {merged ? 'the road runs level here' : `${angle.toFixed(0)}° apart`}
         </text>
       </svg>
       <figcaption className="mt-1 text-center text-[11px] text-[var(--color-text-secondary)]">
-        The staircase's anchors, on the sphere it lives on. Gold arrow: the road's direction at the
-        moon's spot. Silver arrow: the level direction — the parallel of the equator through the
-        same spot. They split by the full 23½° at the crossings, where the staircase peaks, and
-        merge at the turning points, where it dies to nothing.
+        The same slider, on the sphere. The moon's spot rides the gold road; the thin silver ring
+        through it is "level" — no closer to and no further from the equator. The two arrows
+        compare directions: <span className="text-[var(--color-gold)]">where the road goes next</span>{' '}
+        against <span style={{ opacity: 0.8 }}>level along the ring</span>. Their gap is what the
+        staircase plots: the full 23½° at the two crossings, where the slice peaks at two fifths —
+        shrinking to nothing at the turning points, where the road runs level and the slice
+        vanishes.
       </figcaption>
     </figure>
   );
@@ -290,7 +349,9 @@ export default function SliceShape() {
         </svg>
       </figure>
 
-      <SliceSphere lon={n} />
+      <GeometryAside summary="For the curious: why those anchors — the picture on the sphere">
+        <SliceSphere lon={n} />
+      </GeometryAside>
 
       <label className="mt-2 block">
         <span className="text-xs font-bold text-[var(--color-text-secondary)]">

--- a/src/components/book/interactives/StretchShape.jsx
+++ b/src/components/book/interactives/StretchShape.jsx
@@ -29,56 +29,6 @@ import React, { useState } from 'react';
 import InteractiveCard from '../../text/interactives/InteractiveCard';
 import { CONSTANTS } from '../../../engine/constants';
 import { ordinalSuffix } from '../../../engine/zodiac';
-import { eclipticToEquatorial, equatorialToHorizontal, gmstDeg } from '../../../lib/skyView';
-import {
-  makeSphereProjector,
-  flatCircle,
-  circleHalvesProps,
-  GeometryAside,
-} from './sphereProjection';
-
-const DEG = Math.PI / 180;
-/** KH 11:17's "about 32° north" — the latitude the whole table is for. */
-const LATITUDE = 32;
-
-/**
- * The sky over the horizon at the instant the belt's degree `lonDeg`
- * sets, as alt/az of any other belt degree. No clock involved: the
- * sidereal time is CHOSEN so the given degree sits on the western
- * horizon, by handing skyView a synthetic observer longitude.
- */
-function settingFrame(lonDeg) {
-  const jd0 = 2451545.0;
-  const { ra, dec } = eclipticToEquatorial(lonDeg, 0);
-  // Hour angle at setting: cos H = −tan φ · tan δ.
-  const cosH = -Math.tan(LATITUDE * DEG) * Math.tan(dec * DEG);
-  const H = Math.acos(Math.min(1, Math.max(-1, cosH))) / DEG;
-  const observer = { latitude: LATITUDE, longitude: ra + H - gmstDeg(jd0) };
-  return (beltDeg) => {
-    const eq = eclipticToEquatorial(beltDeg, 0);
-    return equatorialToHorizontal(eq.ra, eq.dec, jd0, observer);
-  };
-}
-
-/**
- * The angle at which the belt meets the horizon as `lonDeg` sets —
- * the geometry under KH 17:12. STEEP means the belt's degrees file
- * across the horizon one at a time, so each takes long to set and is
- * worth more (stretch). SHALLOW lays a long run of belt along the
- * horizon and drops it across together — each degree is worth less
- * (shrink). Easy to invert; verified against the classical result
- * (Aries sets slowly at northern latitudes, Virgo–Libra plunge) in
- * ch17figures.test.jsx, and his own table: the −1/3 signs come out
- * shallow, the stretch signs steep.
- */
-export function settingDiveAngle(lonDeg) {
-  const at = settingFrame(lonDeg);
-  const a = at(lonDeg - 2);
-  const b = at(lonDeg + 2);
-  const dAlt = b.altitude - a.altitude;
-  const dAz = ((b.azimuth - a.azimuth + 540) % 360) - 180;
-  return (Math.atan2(Math.abs(dAlt), Math.abs(dAz)) / DEG);
-}
 
 const ROWS = CONSTANTS.SETTING_TIME_BY_MAZAL;
 
@@ -94,130 +44,6 @@ function factorWords(row) {
   const name =
     row.fraction === 1 / 3 ? 'a third' : row.fraction === 1 / 5 ? 'a fifth' : 'a sixth';
   return row.operation === 'add' ? `stretched — add ${name} of it` : `shrunk — take ${name} off it`;
-}
-
-/**
- * The dome itself: Jerusalem's horizon as the sphere's flat circle,
- * the belt frozen at the instant the chosen degree touches it in the
- * west. NOT chapter 19's sphere — no equator here, deliberately: the
- * card's whole point is that setting speed is a fact about the horizon
- * at 32° north, and this figure is that fact drawn. Viewer faces west,
- * north to the right.
- */
-function StretchDome({ lon }) {
-  const w = 520;
-  const h = 220;
-  const cx = w / 2;
-  const cy = h / 2 + 4;
-  const R = 92;
-  const { project } = makeSphereProjector({ cx, cy, R, viewDeg: 40 });
-
-  const at = settingFrame(lon);
-  // alt/az → scene: viewer faces west (−E toward the camera), north right.
-  const scene = ({ altitude, azimuth }) => ({
-    x: Math.cos(altitude * DEG) * Math.cos(azimuth * DEG),
-    y: -Math.cos(altitude * DEG) * Math.sin(azimuth * DEG),
-    z: Math.sin(altitude * DEG),
-  });
-
-  // The belt, split into runs by ONE combined visibility: solid only
-  // where it is both on the camera's side of the ball AND above the
-  // horizon; everything else reads as "behind something".
-  const runs = [];
-  let run = null;
-  let style = null;
-  for (let d = 0; d <= 360; d += 3) {
-    const hor = at(lon + d - 180);
-    const p = project(scene(hor));
-    const s = p.front && hor.altitude > 0 ? 'solid' : 'hidden';
-    if (s !== style) {
-      if (run) runs.push({ style, pts: run });
-      run = [];
-      style = s;
-    }
-    run.push(p);
-  }
-  if (run) runs.push({ style, pts: run });
-
-  const horizonSegs = { front: [], back: [] };
-  const horizonPoly = [];
-  for (let d = 0; d <= 360; d += 3) {
-    const p = project(flatCircle(d * DEG));
-    horizonPoly.push(p);
-    (p.front ? horizonSegs.front : horizonSegs.back).push(p);
-  }
-
-  const setting = project(scene(at(lon)));
-  const under = project(scene(at(lon + (at(lon + 4).altitude < 0 ? 4 : -4))));
-  const dive = settingDiveAngle(lon);
-
-  const compass = [
-    [225, 'SW'],
-    [270, 'W'],
-    [315, 'NW'],
-  ].map(([az, label]) => ({ label, p: project(scene({ altitude: 0, azimuth: az })) }));
-
-  return (
-    <figure className="mt-3">
-      <svg
-        viewBox={`0 0 ${w} ${h}`}
-        className="w-full"
-        role="img"
-        aria-label="A dome over Jerusalem's horizon at the instant the chosen degree of the belt sets in the west; the belt meets the horizon at an angle that is steep for the plunging signs and shallow for the slow-setting ones"
-      >
-        <circle cx={cx} cy={cy} r={R} fill="var(--color-card)" fillOpacity="0.35" stroke="var(--color-border)" strokeWidth="1" />
-        {/* the ground, made faintly solid */}
-        <polygon
-          points={horizonPoly.map((p) => `${p.X.toFixed(1)},${p.Y.toFixed(1)}`).join(' ')}
-          fill="var(--color-card)"
-          fillOpacity="0.5"
-        />
-        {circleHalvesProps(
-          { front: [horizonSegs.front], back: [horizonSegs.back] },
-          'var(--color-silver)',
-          1.5,
-        ).map((p) => (
-          <polyline {...p} />
-        ))}
-
-        {runs.map((r, i) => (
-          <polyline
-            key={i}
-            points={r.pts.map((p) => `${p.X.toFixed(1)},${p.Y.toFixed(1)}`).join(' ')}
-            fill="none"
-            stroke="var(--color-gold)"
-            strokeWidth="1.5"
-            strokeOpacity={r.style === 'solid' ? 0.9 : 0.25}
-            strokeDasharray={r.style === 'solid' ? undefined : '3 3'}
-          />
-        ))}
-
-        {compass.map(({ label, p }) => (
-          <text key={label} x={p.X} y={p.Y + 12} fontSize="8" textAnchor="middle" fill="var(--color-text-secondary)">
-            {label}
-          </text>
-        ))}
-        <text x={cx - R + 4} y={cy + 26} fontSize="8" fill="var(--color-text-secondary)">
-          the horizon — below it, the earth
-        </text>
-
-        {/* the setting degree, and the dive it makes */}
-        <line x1={setting.X} y1={setting.Y} x2={under.X} y2={under.Y} stroke="var(--color-accent)" strokeWidth="1.5" />
-        <circle cx={setting.X} cy={setting.Y} r="4.5" fill="var(--color-accent)" stroke="var(--color-bg)" strokeWidth="1.25" />
-        <text x={setting.X} y={setting.Y - 10} fontSize="9" textAnchor="middle" fill="var(--color-text)">
-          meets the horizon at {dive.toFixed(0)}°
-        </text>
-      </svg>
-      <figcaption className="mt-1 text-center text-[11px] text-[var(--color-text-secondary)]">
-        The moment the moon's degree touches the western horizon, at 32° north. The gold arc is
-        the belt; the angle it makes with the horizon is the whole story. <strong>Steep</strong>,
-        and its degrees file across one at a time — each takes long to set, so each degree of gap
-        is worth more (stretch). <strong>Shallow</strong>, and a long run of belt lies along the
-        horizon and drops across together — each degree worth less (shrink). Not chapter 19's
-        sphere: there is no equator in this picture, because this table never asks for one.
-      </figcaption>
-    </figure>
-  );
 }
 
 export default function StretchShape() {
@@ -315,10 +141,6 @@ export default function StretchShape() {
           <circle cx={x(n)} cy={y(f)} r="4" fill="var(--color-silver)" />
         </svg>
       </figure>
-
-      <GeometryAside summary="For the curious: the belt meeting the horizon — the picture on the dome">
-        <StretchDome lon={n} />
-      </GeometryAside>
 
       <label className="mt-2 block">
         <span className="text-xs font-bold text-[var(--color-text-secondary)]">

--- a/src/components/book/interactives/StretchShape.jsx
+++ b/src/components/book/interactives/StretchShape.jsx
@@ -29,6 +29,51 @@ import React, { useState } from 'react';
 import InteractiveCard from '../../text/interactives/InteractiveCard';
 import { CONSTANTS } from '../../../engine/constants';
 import { ordinalSuffix } from '../../../engine/zodiac';
+import { eclipticToEquatorial, equatorialToHorizontal, gmstDeg } from '../../../lib/skyView';
+import { makeSphereProjector, flatCircle, circleHalvesProps } from './sphereProjection';
+
+const DEG = Math.PI / 180;
+/** KH 11:17's "about 32° north" — the latitude the whole table is for. */
+const LATITUDE = 32;
+
+/**
+ * The sky over the horizon at the instant the belt's degree `lonDeg`
+ * sets, as alt/az of any other belt degree. No clock involved: the
+ * sidereal time is CHOSEN so the given degree sits on the western
+ * horizon, by handing skyView a synthetic observer longitude.
+ */
+function settingFrame(lonDeg) {
+  const jd0 = 2451545.0;
+  const { ra, dec } = eclipticToEquatorial(lonDeg, 0);
+  // Hour angle at setting: cos H = −tan φ · tan δ.
+  const cosH = -Math.tan(LATITUDE * DEG) * Math.tan(dec * DEG);
+  const H = Math.acos(Math.min(1, Math.max(-1, cosH))) / DEG;
+  const observer = { latitude: LATITUDE, longitude: ra + H - gmstDeg(jd0) };
+  return (beltDeg) => {
+    const eq = eclipticToEquatorial(beltDeg, 0);
+    return equatorialToHorizontal(eq.ra, eq.dec, jd0, observer);
+  };
+}
+
+/**
+ * The angle at which the belt meets the horizon as `lonDeg` sets —
+ * the geometry under KH 17:12. STEEP means the belt's degrees file
+ * across the horizon one at a time, so each takes long to set and is
+ * worth more (stretch). SHALLOW lays a long run of belt along the
+ * horizon and drops it across together — each degree is worth less
+ * (shrink). Easy to invert; verified against the classical result
+ * (Aries sets slowly at northern latitudes, Virgo–Libra plunge) in
+ * ch17figures.test.jsx, and his own table: the −1/3 signs come out
+ * shallow, the stretch signs steep.
+ */
+export function settingDiveAngle(lonDeg) {
+  const at = settingFrame(lonDeg);
+  const a = at(lonDeg - 2);
+  const b = at(lonDeg + 2);
+  const dAlt = b.altitude - a.altitude;
+  const dAz = ((b.azimuth - a.azimuth + 540) % 360) - 180;
+  return (Math.atan2(Math.abs(dAlt), Math.abs(dAz)) / DEG);
+}
 
 const ROWS = CONSTANTS.SETTING_TIME_BY_MAZAL;
 
@@ -44,6 +89,130 @@ function factorWords(row) {
   const name =
     row.fraction === 1 / 3 ? 'a third' : row.fraction === 1 / 5 ? 'a fifth' : 'a sixth';
   return row.operation === 'add' ? `stretched — add ${name} of it` : `shrunk — take ${name} off it`;
+}
+
+/**
+ * The dome itself: Jerusalem's horizon as the sphere's flat circle,
+ * the belt frozen at the instant the chosen degree touches it in the
+ * west. NOT chapter 19's sphere — no equator here, deliberately: the
+ * card's whole point is that setting speed is a fact about the horizon
+ * at 32° north, and this figure is that fact drawn. Viewer faces west,
+ * north to the right.
+ */
+function StretchDome({ lon }) {
+  const w = 520;
+  const h = 220;
+  const cx = w / 2;
+  const cy = h / 2 + 4;
+  const R = 92;
+  const { project } = makeSphereProjector({ cx, cy, R, viewDeg: 40 });
+
+  const at = settingFrame(lon);
+  // alt/az → scene: viewer faces west (−E toward the camera), north right.
+  const scene = ({ altitude, azimuth }) => ({
+    x: Math.cos(altitude * DEG) * Math.cos(azimuth * DEG),
+    y: -Math.cos(altitude * DEG) * Math.sin(azimuth * DEG),
+    z: Math.sin(altitude * DEG),
+  });
+
+  // The belt, split into runs by ONE combined visibility: solid only
+  // where it is both on the camera's side of the ball AND above the
+  // horizon; everything else reads as "behind something".
+  const runs = [];
+  let run = null;
+  let style = null;
+  for (let d = 0; d <= 360; d += 3) {
+    const hor = at(lon + d - 180);
+    const p = project(scene(hor));
+    const s = p.front && hor.altitude > 0 ? 'solid' : 'hidden';
+    if (s !== style) {
+      if (run) runs.push({ style, pts: run });
+      run = [];
+      style = s;
+    }
+    run.push(p);
+  }
+  if (run) runs.push({ style, pts: run });
+
+  const horizonSegs = { front: [], back: [] };
+  const horizonPoly = [];
+  for (let d = 0; d <= 360; d += 3) {
+    const p = project(flatCircle(d * DEG));
+    horizonPoly.push(p);
+    (p.front ? horizonSegs.front : horizonSegs.back).push(p);
+  }
+
+  const setting = project(scene(at(lon)));
+  const under = project(scene(at(lon + (at(lon + 4).altitude < 0 ? 4 : -4))));
+  const dive = settingDiveAngle(lon);
+
+  const compass = [
+    [225, 'SW'],
+    [270, 'W'],
+    [315, 'NW'],
+  ].map(([az, label]) => ({ label, p: project(scene({ altitude: 0, azimuth: az })) }));
+
+  return (
+    <figure className="mt-3">
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        className="w-full"
+        role="img"
+        aria-label="A dome over Jerusalem's horizon at the instant the chosen degree of the belt sets in the west; the belt meets the horizon at an angle that is steep for the plunging signs and shallow for the slow-setting ones"
+      >
+        <circle cx={cx} cy={cy} r={R} fill="var(--color-card)" fillOpacity="0.35" stroke="var(--color-border)" strokeWidth="1" />
+        {/* the ground, made faintly solid */}
+        <polygon
+          points={horizonPoly.map((p) => `${p.X.toFixed(1)},${p.Y.toFixed(1)}`).join(' ')}
+          fill="var(--color-card)"
+          fillOpacity="0.5"
+        />
+        {circleHalvesProps(
+          { front: [horizonSegs.front], back: [horizonSegs.back] },
+          'var(--color-silver)',
+          1.5,
+        ).map((p) => (
+          <polyline {...p} />
+        ))}
+
+        {runs.map((r, i) => (
+          <polyline
+            key={i}
+            points={r.pts.map((p) => `${p.X.toFixed(1)},${p.Y.toFixed(1)}`).join(' ')}
+            fill="none"
+            stroke="var(--color-gold)"
+            strokeWidth="1.5"
+            strokeOpacity={r.style === 'solid' ? 0.9 : 0.25}
+            strokeDasharray={r.style === 'solid' ? undefined : '3 3'}
+          />
+        ))}
+
+        {compass.map(({ label, p }) => (
+          <text key={label} x={p.X} y={p.Y + 12} fontSize="8" textAnchor="middle" fill="var(--color-text-secondary)">
+            {label}
+          </text>
+        ))}
+        <text x={cx - R + 4} y={cy + 26} fontSize="8" fill="var(--color-text-secondary)">
+          the horizon — below it, the earth
+        </text>
+
+        {/* the setting degree, and the dive it makes */}
+        <line x1={setting.X} y1={setting.Y} x2={under.X} y2={under.Y} stroke="var(--color-accent)" strokeWidth="1.5" />
+        <circle cx={setting.X} cy={setting.Y} r="4.5" fill="var(--color-accent)" stroke="var(--color-bg)" strokeWidth="1.25" />
+        <text x={setting.X} y={setting.Y - 10} fontSize="9" textAnchor="middle" fill="var(--color-text)">
+          meets the horizon at {dive.toFixed(0)}°
+        </text>
+      </svg>
+      <figcaption className="mt-1 text-center text-[11px] text-[var(--color-text-secondary)]">
+        The moment the moon's degree touches the western horizon, at 32° north. The gold arc is
+        the belt; the angle it makes with the horizon is the whole story. <strong>Steep</strong>,
+        and its degrees file across one at a time — each takes long to set, so each degree of gap
+        is worth more (stretch). <strong>Shallow</strong>, and a long run of belt lies along the
+        horizon and drops across together — each degree worth less (shrink). Not chapter 19's
+        sphere: there is no equator in this picture, because this table never asks for one.
+      </figcaption>
+    </figure>
+  );
 }
 
 export default function StretchShape() {
@@ -141,6 +310,8 @@ export default function StretchShape() {
           <circle cx={x(n)} cy={y(f)} r="4" fill="var(--color-silver)" />
         </svg>
       </figure>
+
+      <StretchDome lon={n} />
 
       <label className="mt-2 block">
         <span className="text-xs font-bold text-[var(--color-text-secondary)]">

--- a/src/components/book/interactives/StretchShape.jsx
+++ b/src/components/book/interactives/StretchShape.jsx
@@ -30,7 +30,12 @@ import InteractiveCard from '../../text/interactives/InteractiveCard';
 import { CONSTANTS } from '../../../engine/constants';
 import { ordinalSuffix } from '../../../engine/zodiac';
 import { eclipticToEquatorial, equatorialToHorizontal, gmstDeg } from '../../../lib/skyView';
-import { makeSphereProjector, flatCircle, circleHalvesProps } from './sphereProjection';
+import {
+  makeSphereProjector,
+  flatCircle,
+  circleHalvesProps,
+  GeometryAside,
+} from './sphereProjection';
 
 const DEG = Math.PI / 180;
 /** KH 11:17's "about 32° north" — the latitude the whole table is for. */
@@ -311,7 +316,9 @@ export default function StretchShape() {
         </svg>
       </figure>
 
-      <StretchDome lon={n} />
+      <GeometryAside summary="For the curious: the belt meeting the horizon — the picture on the dome">
+        <StretchDome lon={n} />
+      </GeometryAside>
 
       <label className="mt-2 block">
         <span className="text-xs font-bold text-[var(--color-text-secondary)]">

--- a/src/components/book/interactives/TonightHere.jsx
+++ b/src/components/book/interactives/TonightHere.jsx
@@ -41,13 +41,54 @@ import {
   THIRD_OF_AN_HOUR_MINUTES,
 } from '../../../lib/localObserver';
 import { zodiacPosition, ordinalSuffix } from '../../../engine/zodiac';
+import { nextSightingNight } from '../../../lib/sightingNight';
+import { dateFromEpochDays, HDate } from '../../../engine/epochDays';
+
+const isoOf = (d) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 
 function todayIso() {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  return isoOf(new Date());
+}
+
+/**
+ * The civil evening of the next sighting night at or after `from` — the
+ * same derivation as /sky's eveningOf: engine day N is the evening
+ * beginning Hebrew day N, whose civil date is dateFromEpochDays(N) − 1.
+ * This is the card's default. An earlier version opened on today, which
+ * is usually mid-month — a verdict on an evening nobody would watch.
+ */
+function sightingIso(from = new Date()) {
+  const eve = new Date(dateFromEpochDays(nextSightingNight(from).days));
+  eve.setDate(eve.getDate() - 1);
+  return isoOf(eve);
+}
+
+/** The sighting night of the month after the one `iso` sits in. */
+function followingSightingIso(iso) {
+  const parts = iso.split('-').map(Number);
+  const base =
+    parts.length === 3 && !parts.some(Number.isNaN)
+      ? new Date(parts[0], parts[1] - 1, parts[2], 12)
+      : new Date();
+  // +5 days clears this month's window (the preset can land up to two
+  // evenings past the 29th) while staying well short of the next 29th.
+  base.setDate(base.getDate() + 5);
+  return sightingIso(base);
 }
 
 const signed = (n, digits = 1) => `${n >= 0 ? '+' : '−'}${Math.abs(n).toFixed(digits)}`;
+
+function PresetButton({ onClick, children }) {
+  return (
+    <button
+      onClick={onClick}
+      className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-xs text-[var(--color-text-secondary)] hover:bg-[var(--color-border)]"
+    >
+      {children}
+    </button>
+  );
+}
 
 /** Which KH 17:3-4 half the moon is in, and hence which thresholds. */
 function halfFor(longitude) {
@@ -58,7 +99,7 @@ function halfFor(longitude) {
 }
 
 export default function TonightHere() {
-  const [iso, setIso] = useState(todayIso);
+  const [iso, setIso] = useState(sightingIso);
   const [lat, setLat] = useState(String(KARMIEL.latitude));
   const [lon, setLon] = useState(String(KARMIEL.longitude));
   const [elev, setElev] = useState(String(KARMIEL.elevationM));
@@ -89,6 +130,10 @@ export default function TonightHere() {
         calc: getFullCalculation(nextNoon),
         base: rambamWindow(date),
         local: localOffsets(date, observer),
+        // The Hebrew day this civil evening begins — so the reader can
+        // see whether they are looking at ליל שלושים or a mid-month night.
+        hebrew: new HDate(nextNoon).toString(),
+        hebrewDay: new HDate(nextNoon).getDate(),
       };
     } catch {
       return null;
@@ -131,15 +176,30 @@ export default function TonightHere() {
       source="KH 17 verdict · KH 14:6 moment"
       blurb="his answer first, then the offsets that turn it into a clock time"
     >
-      <label className="block">
-        <span className="text-xs font-bold text-[var(--color-text-secondary)]">Evening of</span>
-        <input
-          type="date"
-          value={iso}
-          onChange={(e) => setIso(e.target.value)}
-          className="mt-1 ml-2 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 font-mono text-sm"
-        />
-      </label>
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="block">
+          <span className="text-xs font-bold text-[var(--color-text-secondary)]">Evening of</span>
+          <input
+            type="date"
+            value={iso}
+            onChange={(e) => setIso(e.target.value)}
+            className="mt-1 ml-2 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 font-mono text-sm"
+          />
+        </label>
+        <PresetButton onClick={() => setIso(sightingIso())}>Next sighting night</PresetButton>
+        <PresetButton onClick={() => setIso(followingSightingIso(iso))}>
+          The month after
+        </PresetButton>
+        <PresetButton onClick={() => setIso(todayIso())}>Tonight</PresetButton>
+      </div>
+      <p className="mt-1 text-[11px] text-[var(--color-text-secondary)]">
+        This evening begins <strong>{data.hebrew}</strong>
+        {data.hebrewDay === 30 || data.hebrewDay <= 2
+          ? ' — a night the court would actually be watching.'
+          : data.hebrewDay >= 27
+            ? ' — close to the watching nights at the month\'s end.'
+            : ' — mid-month, so the verdict below answers a question no court would ask; jump to the next sighting night for the real one.'}
+      </p>
 
       {/* ── LAYER 1: his verdict, no observer anywhere in it ── */}
       <div

--- a/src/components/book/interactives/ch17figures.test.jsx
+++ b/src/components/book/interactives/ch17figures.test.jsx
@@ -12,7 +12,7 @@
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import ParallaxBySign, { wholeShiftArcmin } from './ParallaxBySign';
 import { CONSTANTS } from '../../../engine/constants';
 
@@ -42,5 +42,28 @@ describe("the parallax triangle's claim: one shift, split by sign", () => {
     render(<ParallaxBySign />);
     expect(screen.getByText(/He gives only the two tables/)).toBeTruthy();
     expect(screen.getByText(/KH 17:24/)).toBeTruthy();
+  });
+});
+
+describe('the early-exit card computes real nights', () => {
+  // Deferred import keeps the top of the file about the parallax figure.
+  it("opens on his worked evening, engine-computed, and knows it isn't settled", async () => {
+    const { default: QuickVerdict } = await import('./QuickVerdict');
+    render(<QuickVerdict />);
+    // The evening of 2 Iyar 4938 — 1178-04-27 civil.
+    expect(screen.getByText('1178-04-27')).toBeTruthy();
+    expect(screen.getByText(/computed by the engine/)).toBeTruthy();
+    // His evening sits in the undecided band (9° < 11°27' ≤ 15°), which
+    // is exactly why KH 17 continues past the early exit.
+    expect(screen.getByText(/Not settled — the long chain is needed/)).toBeTruthy();
+  });
+
+  it('drops the engine claim the moment a slider is moved by hand', async () => {
+    const { default: QuickVerdict } = await import('./QuickVerdict');
+    render(<QuickVerdict />);
+    const slider = screen.getByLabelText('First longitude in degrees');
+    fireEvent.change(slider, { target: { value: '20' } });
+    expect(screen.getByText(/Set by hand/)).toBeTruthy();
+    expect(screen.queryByText(/computed by the engine/)).toBeNull();
   });
 });

--- a/src/components/book/interactives/ch17figures.test.jsx
+++ b/src/components/book/interactives/ch17figures.test.jsx
@@ -29,10 +29,11 @@ describe("the parallax triangle's claim: one shift, split by sign", () => {
     }
   });
 
-  it('renders the triangle with both components named', () => {
+  it('renders the triangle with both components named in the legend', () => {
     render(<ParallaxBySign />);
-    expect(screen.getByText(/along the belt: .*off the gap/)).toBeTruthy();
-    expect(screen.getByText(/across it: \d+′ onto the height/)).toBeTruthy();
+    expect(screen.getByText(/along the belt — off the gap: .*′/)).toBeTruthy();
+    expect(screen.getByText(/across it — onto the height: \d+′/)).toBeTruthy();
+    expect(screen.getByText(/the whole shift: \d+′/)).toBeTruthy();
     expect(screen.getByText(/where it is seen — \d+′ away/)).toBeTruthy();
   });
 

--- a/src/components/book/interactives/ch17figures.test.jsx
+++ b/src/components/book/interactives/ch17figures.test.jsx
@@ -29,18 +29,13 @@ describe("the parallax triangle's claim: one shift, split by sign", () => {
     }
   });
 
-  it('renders as the two-moons story: really here, seen here, one push in two parts', () => {
+  it('states the constant-total fact in prose, with its provenance', () => {
+    // The figure that carried this fact was removed — it leaned on
+    // "first table / second table" language and cryptic numbers. The
+    // fact survives as one sentence beside the curves, still owned as
+    // this book's observation, not his.
     render(<ParallaxBySign />);
-    expect(screen.getByText('the moon is really here')).toBeTruthy();
-    expect(screen.getByText('your eye sees it here')).toBeTruthy();
-    expect(screen.getByText(/the whole push: \d+′/)).toBeTruthy();
-    expect(screen.getByText(/the sideways part: .*′ — the first table/)).toBeTruthy();
-    expect(screen.getByText(/the downward part: \d+′ — the second table/)).toBeTruthy();
-  });
-
-  it('says whose the mechanism is: his tables, our triangle', () => {
-    render(<ParallaxBySign />);
-    expect(screen.getByText(/He gives only the two tables/)).toBeTruthy();
+    expect(screen.getByText(/between 56′ and 61′/)).toBeTruthy();
     expect(screen.getByText(/KH 17:24/)).toBeTruthy();
   });
 });

--- a/src/components/book/interactives/ch17figures.test.jsx
+++ b/src/components/book/interactives/ch17figures.test.jsx
@@ -29,12 +29,13 @@ describe("the parallax triangle's claim: one shift, split by sign", () => {
     }
   });
 
-  it('renders the triangle with both components named in the legend', () => {
+  it('renders as the two-moons story: really here, seen here, one push in two parts', () => {
     render(<ParallaxBySign />);
-    expect(screen.getByText(/along the belt — off the gap: .*′/)).toBeTruthy();
-    expect(screen.getByText(/across it — onto the height: \d+′/)).toBeTruthy();
-    expect(screen.getByText(/the whole shift: \d+′/)).toBeTruthy();
-    expect(screen.getByText(/where it is seen — \d+′ away/)).toBeTruthy();
+    expect(screen.getByText('the moon is really here')).toBeTruthy();
+    expect(screen.getByText('your eye sees it here')).toBeTruthy();
+    expect(screen.getByText(/the whole push: \d+′/)).toBeTruthy();
+    expect(screen.getByText(/the sideways part: .*′ — the first table/)).toBeTruthy();
+    expect(screen.getByText(/the downward part: \d+′ — the second table/)).toBeTruthy();
   });
 
   it('says whose the mechanism is: his tables, our triangle', () => {

--- a/src/components/book/interactives/ch17figures.test.jsx
+++ b/src/components/book/interactives/ch17figures.test.jsx
@@ -1,77 +1,22 @@
 // @vitest-environment jsdom
 /**
- * The chapter-17 geometry figures added at a reader's request: a sphere
- * behind the slice, a horizon dome behind the stretch, and a triangle
- * behind the two parallax tables. Each figure makes a checkable claim;
- * these tests check them, not the pixels.
+ * The parallax triangle on the two-tables card. Two sphere figures
+ * (slice, stretch) were added alongside it and then REMOVED at the
+ * same reader's request — diagrams that puzzled more than they taught.
+ * The triangle stayed because it is flat and is itself the explanation:
+ * one shift of nearly constant size, split by the belt's slant. Its
+ * checkable claim is pinned here, and so is its provenance line — the
+ * Rambam gives the tables and no reasons (KH 17:24 says the whys live
+ * in the Greek geometry books), so the card must say the mechanism is
+ * our reconstruction, not his statement.
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
-import SliceShape, { roadLevelAngle } from './SliceShape';
-import StretchShape, { settingDiveAngle } from './StretchShape';
 import ParallaxBySign, { wholeShiftArcmin } from './ParallaxBySign';
-import { MAX_TILT } from '../../../lib/khDeclination';
 import { CONSTANTS } from '../../../engine/constants';
 
 afterEach(cleanup);
-
-describe("the slice sphere's claim: road-against-level angle", () => {
-  it('is the full 23½° at the crossings and nothing at the turning points', () => {
-    expect(roadLevelAngle(0)).toBeCloseTo(MAX_TILT, 1);
-    expect(roadLevelAngle(180)).toBeCloseTo(MAX_TILT, 1);
-    expect(roadLevelAngle(90)).toBeCloseTo(0, 1);
-    expect(roadLevelAngle(270)).toBeCloseTo(0, 1);
-  });
-
-  it('tracks the staircase: bigger fraction, bigger angle', () => {
-    // The peak band (2/5) sits at a larger angle than the 1/6 band.
-    expect(roadLevelAngle(10)).toBeGreaterThan(roadLevelAngle(75));
-  });
-
-  it('renders with both arrows labelled on the drawing, inside an aside', () => {
-    render(<SliceShape />);
-    expect(screen.getByText(/° apart/)).toBeTruthy();
-    expect(screen.getAllByText('where the road goes next').length).toBeGreaterThan(0);
-    expect(screen.getByText(/level — along its ring/)).toBeTruthy();
-    // Collapsed by default: regular readers get the staircase alone.
-    expect(screen.getByText(/For the curious: why those anchors/)).toBeTruthy();
-  });
-});
-
-describe("the stretch dome's claim: the belt's dive at setting", () => {
-  it('shallow for the deep-shrink signs, steep for the stretch signs', () => {
-    // Steep = degrees file across one at a time = slow = stretch; his
-    // stretches sit around the 12th and 1st signs (Aries sets slowly at
-    // northern latitudes — the classical long descension). Shallow =
-    // a run of belt drops across together = fast = shrink; his deepest
-    // shrink (−1/3) covers the 6th and 7th. Mid-sign sample points.
-    const shrink6 = settingDiveAngle(165);
-    const shrink7 = settingDiveAngle(195);
-    const stretch12 = settingDiveAngle(345);
-    const stretch1 = settingDiveAngle(15);
-    expect(shrink6).toBeLessThan(45);
-    expect(shrink7).toBeLessThan(45);
-    expect(stretch12).toBeGreaterThan(60);
-    expect(stretch1).toBeGreaterThan(60);
-  });
-
-  it('stays within the geometric bounds for 32° north', () => {
-    // The belt-horizon angle at setting swings around 90° − φ by
-    // roughly the obliquity: ~30° to ~85° at φ = 32.
-    for (let d = 0; d < 360; d += 15) {
-      const a = settingDiveAngle(d);
-      expect(a, `at ${d}°`).toBeGreaterThan(25);
-      expect(a, `at ${d}°`).toBeLessThan(88);
-    }
-  });
-
-  it('renders the dome with its angle readout and its no-equator stance', () => {
-    render(<StretchShape />);
-    expect(screen.getByText(/meets the horizon at \d+°/)).toBeTruthy();
-    expect(screen.getByText(/there is no\s+equator in this picture/)).toBeTruthy();
-  });
-});
 
 describe("the parallax triangle's claim: one shift, split by sign", () => {
   it('the whole shift is nearly constant across all twelve signs', () => {
@@ -89,5 +34,11 @@ describe("the parallax triangle's claim: one shift, split by sign", () => {
     expect(screen.getByText(/along the belt: .*off the gap/)).toBeTruthy();
     expect(screen.getByText(/across it: \d+′ onto the height/)).toBeTruthy();
     expect(screen.getByText(/where it is seen — \d+′ away/)).toBeTruthy();
+  });
+
+  it('says whose the mechanism is: his tables, our triangle', () => {
+    render(<ParallaxBySign />);
+    expect(screen.getByText(/He gives only the two tables/)).toBeTruthy();
+    expect(screen.getByText(/KH 17:24/)).toBeTruthy();
   });
 });

--- a/src/components/book/interactives/ch17figures.test.jsx
+++ b/src/components/book/interactives/ch17figures.test.jsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+/**
+ * The chapter-17 geometry figures added at a reader's request: a sphere
+ * behind the slice, a horizon dome behind the stretch, and a triangle
+ * behind the two parallax tables. Each figure makes a checkable claim;
+ * these tests check them, not the pixels.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import SliceShape, { roadLevelAngle } from './SliceShape';
+import StretchShape, { settingDiveAngle } from './StretchShape';
+import ParallaxBySign, { wholeShiftArcmin } from './ParallaxBySign';
+import { MAX_TILT } from '../../../lib/khDeclination';
+import { CONSTANTS } from '../../../engine/constants';
+
+afterEach(cleanup);
+
+describe("the slice sphere's claim: road-against-level angle", () => {
+  it('is the full 23½° at the crossings and nothing at the turning points', () => {
+    expect(roadLevelAngle(0)).toBeCloseTo(MAX_TILT, 1);
+    expect(roadLevelAngle(180)).toBeCloseTo(MAX_TILT, 1);
+    expect(roadLevelAngle(90)).toBeCloseTo(0, 1);
+    expect(roadLevelAngle(270)).toBeCloseTo(0, 1);
+  });
+
+  it('tracks the staircase: bigger fraction, bigger angle', () => {
+    // The peak band (2/5) sits at a larger angle than the 1/6 band.
+    expect(roadLevelAngle(10)).toBeGreaterThan(roadLevelAngle(75));
+  });
+
+  it('renders with both arrows explained', () => {
+    render(<SliceShape />);
+    expect(screen.getByText(/° apart/)).toBeTruthy();
+    expect(screen.getByText(/Silver arrow: the level direction/)).toBeTruthy();
+  });
+});
+
+describe("the stretch dome's claim: the belt's dive at setting", () => {
+  it('shallow for the deep-shrink signs, steep for the stretch signs', () => {
+    // Steep = degrees file across one at a time = slow = stretch; his
+    // stretches sit around the 12th and 1st signs (Aries sets slowly at
+    // northern latitudes — the classical long descension). Shallow =
+    // a run of belt drops across together = fast = shrink; his deepest
+    // shrink (−1/3) covers the 6th and 7th. Mid-sign sample points.
+    const shrink6 = settingDiveAngle(165);
+    const shrink7 = settingDiveAngle(195);
+    const stretch12 = settingDiveAngle(345);
+    const stretch1 = settingDiveAngle(15);
+    expect(shrink6).toBeLessThan(45);
+    expect(shrink7).toBeLessThan(45);
+    expect(stretch12).toBeGreaterThan(60);
+    expect(stretch1).toBeGreaterThan(60);
+  });
+
+  it('stays within the geometric bounds for 32° north', () => {
+    // The belt-horizon angle at setting swings around 90° − φ by
+    // roughly the obliquity: ~30° to ~85° at φ = 32.
+    for (let d = 0; d < 360; d += 15) {
+      const a = settingDiveAngle(d);
+      expect(a, `at ${d}°`).toBeGreaterThan(25);
+      expect(a, `at ${d}°`).toBeLessThan(88);
+    }
+  });
+
+  it('renders the dome with its angle readout and its no-equator stance', () => {
+    render(<StretchShape />);
+    expect(screen.getByText(/meets the horizon at \d+°/)).toBeTruthy();
+    expect(screen.getByText(/there is no\s+equator in this picture/)).toBeTruthy();
+  });
+});
+
+describe("the parallax triangle's claim: one shift, split by sign", () => {
+  it('the whole shift is nearly constant across all twelve signs', () => {
+    // √(lon² + lat²) lands within 56′–61′ everywhere — the moon's own
+    // horizontal parallax (~57′) showing through his two tables.
+    for (let i = 0; i < 12; i++) {
+      const whole = wholeShiftArcmin(i);
+      expect(whole, CONSTANTS.PARALLAX_LON_BY_MAZAL[i].hebrew).toBeGreaterThan(56);
+      expect(whole, CONSTANTS.PARALLAX_LON_BY_MAZAL[i].hebrew).toBeLessThan(61);
+    }
+  });
+
+  it('renders the triangle with both components named', () => {
+    render(<ParallaxBySign />);
+    expect(screen.getByText(/along the belt: .*off the gap/)).toBeTruthy();
+    expect(screen.getByText(/across it: \d+′ onto the height/)).toBeTruthy();
+    expect(screen.getByText(/where it is seen — \d+′ away/)).toBeTruthy();
+  });
+});

--- a/src/components/book/interactives/ch17figures.test.jsx
+++ b/src/components/book/interactives/ch17figures.test.jsx
@@ -29,10 +29,13 @@ describe("the slice sphere's claim: road-against-level angle", () => {
     expect(roadLevelAngle(10)).toBeGreaterThan(roadLevelAngle(75));
   });
 
-  it('renders with both arrows explained', () => {
+  it('renders with both arrows labelled on the drawing, inside an aside', () => {
     render(<SliceShape />);
     expect(screen.getByText(/° apart/)).toBeTruthy();
-    expect(screen.getByText(/Silver arrow: the level direction/)).toBeTruthy();
+    expect(screen.getAllByText('where the road goes next').length).toBeGreaterThan(0);
+    expect(screen.getByText(/level — along its ring/)).toBeTruthy();
+    // Collapsed by default: regular readers get the staircase alone.
+    expect(screen.getByText(/For the curious: why those anchors/)).toBeTruthy();
   });
 });
 

--- a/src/components/book/interactives/declination.test.jsx
+++ b/src/components/book/interactives/declination.test.jsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+/**
+ * The declination card's sphere figure.
+ *
+ * A reader asked for the dashboard's globe, cut down to the two lines
+ * chapter 19 needs — the equator and the sun's road as great circles,
+ * with the tabulated inclination visible as a meridian arc. These pin
+ * that the sphere and the wave both render, share the slider, and that
+ * the sphere carries the chapter's own landmarks: the two crossings,
+ * the pole every meridian runs through, and the arc's value in words.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import Declination from './Declination';
+import { declinationAt } from '../../../lib/khDeclination';
+
+afterEach(cleanup);
+
+describe('the sphere above the wave', () => {
+  it('draws both figures: each names the equator and the road', () => {
+    render(<Declination />);
+    expect(screen.getAllByText('the equator').length).toBe(2);
+    expect(screen.getAllByText("the sun's road").length).toBe(2);
+  });
+
+  it("carries the chapter's landmarks: the crossings and the pole", () => {
+    render(<Declination />);
+    expect(screen.getByText('Taleh 0°')).toBeTruthy();
+    expect(screen.getByText('Moznayim 180°')).toBeTruthy();
+    expect(screen.getByText('the pole of the equator')).toBeTruthy();
+  });
+
+  it("opens on his evening with the arc labelled north, matching the table", () => {
+    render(<Declination />);
+    const tilt = declinationAt(49);
+    expect(tilt).toBeGreaterThan(0);
+    expect(screen.getByText(`${tilt.toFixed(1)}° north`)).toBeTruthy();
+  });
+
+  it('follows the slider to the equator and to the south', () => {
+    render(<Declination />);
+    const slider = screen.getByLabelText("Position along the sun's road, in degrees");
+    fireEvent.change(slider, { target: { value: '180' } });
+    // On the crossing the point label and the readout both say so.
+    expect(screen.getAllByText(/on the equator/).length).toBeGreaterThan(0);
+    fireEvent.change(slider, { target: { value: '270' } });
+    expect(screen.getByText(`${Math.abs(declinationAt(270)).toFixed(1)}° south`)).toBeTruthy();
+  });
+});

--- a/src/components/book/interactives/sphereProjection.js
+++ b/src/components/book/interactives/sphereProjection.js
@@ -1,0 +1,81 @@
+/**
+ * Shared orthographic-sphere machinery for the book's globe figures.
+ *
+ * ═══════════════════════════════════════════════════════════════════
+ *  REGIME TAG: **modern** — drawing geometry only, no doctrine in it
+ *  SURFACE CATEGORY: internal UI helper (teaching figures)
+ * ═══════════════════════════════════════════════════════════════════
+ *
+ * One projector, several spheres: chapter 19's equator-and-road globe,
+ * chapter 17's slice sphere (same two circles, different annotation)
+ * and stretch dome (horizon and belt). Scene coordinates are x to the
+ * right, z up, y toward the viewer; the camera sits `viewDeg` above
+ * the x-y plane. Great circles come back split into front and back
+ * runs so the back can be dashed — that split is what makes a flat
+ * projection read as a ball.
+ */
+
+const DEG = Math.PI / 180;
+
+/** A projector for a sphere of radius R centred at (cx, cy) on screen. */
+export function makeSphereProjector({ cx, cy, R, viewDeg }) {
+  const view = viewDeg * DEG;
+  const project = ({ x, y, z }) => ({
+    X: cx + R * x,
+    Y: cy - R * (-y * Math.sin(view) + z * Math.cos(view)),
+    front: y * Math.cos(view) + z * Math.sin(view) > 0,
+  });
+
+  /**
+   * A closed curve, sampled every 3° and split into front/back runs.
+   * `pointAt` maps a parameter in radians to a scene-space unit vector.
+   */
+  const halves = (pointAt) => {
+    const segs = { front: [], back: [] };
+    let run = [];
+    let side = null;
+    for (let d = 0; d <= 360; d += 3) {
+      const p = project(pointAt(d * DEG));
+      const s = p.front ? 'front' : 'back';
+      if (side !== null && s !== side) {
+        segs[side].push(run);
+        run = [];
+      }
+      run.push(p);
+      side = s;
+    }
+    if (run.length) segs[side].push(run);
+    return segs;
+  };
+
+  return { project, halves };
+}
+
+/** Unit vector on the x-y plane's great circle (an "equator"). */
+export const flatCircle = (t) => ({ x: Math.cos(t), y: Math.sin(t), z: 0 });
+
+/** That circle tilted by `epsRad` about the x-axis (an "ecliptic"). */
+export const tiltedCircle = (epsRad) => (t) => ({
+  x: Math.cos(t),
+  y: Math.sin(t) * Math.cos(epsRad),
+  z: Math.sin(t) * Math.sin(epsRad),
+});
+
+/** Front/back runs of a curve as SVG polyline props, back dashed. */
+export function circleHalvesProps(segs, color, width) {
+  const out = [];
+  for (const side of ['back', 'front']) {
+    segs[side].forEach((seg, i) => {
+      out.push({
+        key: `${side}${i}`,
+        points: seg.map((p) => `${p.X.toFixed(1)},${p.Y.toFixed(1)}`).join(' '),
+        fill: 'none',
+        stroke: color,
+        strokeWidth: width,
+        strokeOpacity: side === 'front' ? 0.9 : 0.28,
+        strokeDasharray: side === 'front' ? undefined : '3 3',
+      });
+    });
+  }
+  return out;
+}

--- a/src/components/book/interactives/sphereProjection.js
+++ b/src/components/book/interactives/sphereProjection.js
@@ -14,6 +14,7 @@
  * runs so the back can be dashed — that split is what makes a flat
  * projection read as a ball.
  */
+import React from 'react';
 
 const DEG = Math.PI / 180;
 
@@ -60,6 +61,29 @@ export const tiltedCircle = (epsRad) => (t) => ({
   y: Math.sin(t) * Math.cos(epsRad),
   z: Math.sin(t) * Math.sin(epsRad),
 });
+
+/**
+ * Where the 3D figures live: collapsed by default. The spheres earn
+ * their keep for readers who think geometrically, but the cards must
+ * read complete without them — a reader told us the sphere was more
+ * puzzling than the staircase it explained. React's <details> handles
+ * the state; no JS.
+ */
+export function GeometryAside({ summary, children }) {
+  return React.createElement(
+    'details',
+    { className: 'mt-3 rounded-lg border border-[var(--color-border)]/60 px-3 py-2' },
+    React.createElement(
+      'summary',
+      {
+        className:
+          'cursor-pointer select-none text-[11px] font-bold text-[var(--color-text-secondary)]',
+      },
+      summary,
+    ),
+    children,
+  );
+}
 
 /** Front/back runs of a curve as SVG polyline props, back dashed. */
 export function circleHalvesProps(segs, color, width) {

--- a/src/components/book/interactives/sphereProjection.js
+++ b/src/components/book/interactives/sphereProjection.js
@@ -14,7 +14,6 @@
  * runs so the back can be dashed — that split is what makes a flat
  * projection read as a ball.
  */
-import React from 'react';
 
 const DEG = Math.PI / 180;
 
@@ -61,29 +60,6 @@ export const tiltedCircle = (epsRad) => (t) => ({
   y: Math.sin(t) * Math.cos(epsRad),
   z: Math.sin(t) * Math.sin(epsRad),
 });
-
-/**
- * Where the 3D figures live: collapsed by default. The spheres earn
- * their keep for readers who think geometrically, but the cards must
- * read complete without them — a reader told us the sphere was more
- * puzzling than the staircase it explained. React's <details> handles
- * the state; no JS.
- */
-export function GeometryAside({ summary, children }) {
-  return React.createElement(
-    'details',
-    { className: 'mt-3 rounded-lg border border-[var(--color-border)]/60 px-3 py-2' },
-    React.createElement(
-      'summary',
-      {
-        className:
-          'cursor-pointer select-none text-[11px] font-bold text-[var(--color-text-secondary)]',
-      },
-      summary,
-    ),
-    children,
-  );
-}
 
 /** Front/back runs of a curve as SVG polyline props, back dashed. */
 export function circleHalvesProps(segs, color, width) {

--- a/src/components/book/thirteenNumbers.test.jsx
+++ b/src/components/book/thirteenNumbers.test.jsx
@@ -72,8 +72,9 @@ describe('the five pairs, from the constants', () => {
     }
     // The sun's rate carries the operative third of a second.
     expect(screen.getByText(/0° 59′ 8\.33″ a day/)).toBeTruthy();
-    // The node runs backwards, and the page says so.
-    expect(screen.getByText(/backwards/)).toBeTruthy();
+    // The node runs backwards, and the page says so (in the table and
+    // again in the odd-ones section).
+    expect(screen.getAllByText(/backwards/).length).toBeGreaterThan(0);
   });
 
   it('cites the epoch and each statement', () => {
@@ -82,6 +83,16 @@ describe('the five pairs, from the constants', () => {
     for (const ref of ['KH 12:1-2', 'KH 12:2', 'KH 14:1, 14:4', 'KH 14:3-4', 'KH 16:2-3']) {
       expect(screen.getByText(ref)).toBeTruthy();
     }
+  });
+});
+
+describe('the two odd ones', () => {
+  it('states the stakes of each: the gap transfer, and the heaviest lever', () => {
+    page();
+    expect(screen.getByText(/lands one-for-one in/)).toBeTruthy();
+    expect(screen.getByText(/up to 5°, north or south/)).toBeTruthy();
+    expect(screen.getByText(/no\s+eclipse of the sun every month/)).toBeTruthy();
+    expect(screen.getByText(/full lap in about 18.6 years/)).toBeTruthy();
   });
 });
 

--- a/src/components/book/thirteenNumbers.test.jsx
+++ b/src/components/book/thirteenNumbers.test.jsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+/**
+ * The thirteen-numbers article. Its one hard promise is that every
+ * figure on the page comes from the engine's constants, so article and
+ * calculators cannot disagree — these tests hold the rendered text to
+ * the constants, and count the foundations to exactly thirteen.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, cleanup } from '@testing-library/react';
+import ThirteenNumbers from './ThirteenNumbers';
+import { CONSTANTS } from '../../engine/constants';
+import {
+  BAHARAD,
+  SYNODIC_MONTH_PARTS,
+  PARTS_PER_DAY,
+  PARTS_PER_HOUR,
+} from '../../engine/fixedCalendar/constants';
+
+afterEach(cleanup);
+
+const page = () =>
+  render(
+    <MemoryRouter>
+      <ThirteenNumbers />
+    </MemoryRouter>,
+  );
+
+describe('the calendar three, from the constants', () => {
+  it('states the month as the decomposition of SYNODIC_MONTH_PARTS', () => {
+    page();
+    const d = Math.floor(SYNODIC_MONTH_PARTS / PARTS_PER_DAY);
+    const h = Math.floor((SYNODIC_MONTH_PARTS % PARTS_PER_DAY) / PARTS_PER_HOUR);
+    const p = SYNODIC_MONTH_PARTS % PARTS_PER_HOUR;
+    expect(d).toBe(29);
+    expect(screen.getByText(new RegExp(`The month: ${d} days, ${h} hours, ${p} parts`))).toBeTruthy();
+  });
+
+  it('states BaHaRaD from the BAHARAD constant', () => {
+    page();
+    expect(
+      screen.getByText(
+        new RegExp(`day ${BAHARAD.dayOfWeek} \\(Monday\\), ${BAHARAD.hours} hours, ${BAHARAD.parts} parts`),
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText(/Seven leap years in every nineteen/)).toBeTruthy();
+  });
+});
+
+describe('the five pairs, from the constants', () => {
+  it('renders each epoch position and daily speed as the engine holds them', () => {
+    page();
+    const shown = [
+      [CONSTANTS.SUN.START_POSITION, '1st sign'],
+      [CONSTANTS.SUN.APOGEE_START, '3rd sign'],
+      [CONSTANTS.MOON.START_POSITION, '2nd sign'],
+      [CONSTANTS.MOON.MASLUL_START, null],
+      [CONSTANTS.NODE.START_POSITION, null],
+    ];
+    for (const [pos] of shown) {
+      const re = new RegExp(`${pos.degrees}° ${pos.minutes}′ ${pos.seconds}″`);
+      expect(screen.getByText(re), re.source).toBeTruthy();
+    }
+    for (const rate of [
+      CONSTANTS.MOON.MEAN_MOTION_PER_DAY,
+      CONSTANTS.MOON.MASLUL_MEAN_MOTION,
+      CONSTANTS.NODE.DAILY_MOTION,
+    ]) {
+      const re = new RegExp(`${rate.degrees}° ${rate.minutes}′ ${rate.seconds}″`);
+      expect(screen.getByText(re), re.source).toBeTruthy();
+    }
+    // The sun's rate carries the operative third of a second.
+    expect(screen.getByText(/0° 59′ 8\.33″ a day/)).toBeTruthy();
+    // The node runs backwards, and the page says so.
+    expect(screen.getByText(/backwards/)).toBeTruthy();
+  });
+
+  it('cites the epoch and each statement', () => {
+    page();
+    expect(screen.getByText(/3 Nisan 4938 \(KH 11:16\)/)).toBeTruthy();
+    for (const ref of ['KH 12:1-2', 'KH 12:2', 'KH 14:1, 14:4', 'KH 14:3-4', 'KH 16:2-3']) {
+      expect(screen.getByText(ref)).toBeTruthy();
+    }
+  });
+});
+
+describe('the count and the funnel', () => {
+  it('really is thirteen: 3 + 5 anchors + 5 speeds', () => {
+    // The page's arithmetic, kept honest: three calendar numbers and
+    // five position/speed pairs.
+    expect(3 + 5 * 2).toBe(13);
+  });
+
+  it('ends at the one number the verdict reads, and owns its framing', () => {
+    page();
+    expect(screen.getByText('קשת הראייה')).toBeTruthy();
+    expect(screen.getByText(/counting the foundations to thirteen — is this book's/)).toBeTruthy();
+  });
+});

--- a/src/components/book/thirteenNumbers.test.jsx
+++ b/src/components/book/thirteenNumbers.test.jsx
@@ -87,12 +87,15 @@ describe('the five pairs, from the constants', () => {
 });
 
 describe('the window opening', () => {
-  it('starts where the reader stands and derives the need', () => {
+  it('starts where the reader stands and derives the need, in plain words', () => {
     page();
     expect(screen.getByText(/Start at the window/)).toBeTruthy();
-    expect(screen.getByText(/how dark it will be,\s*and when/)).toBeTruthy();
-    expect(screen.getByText(/does not set in one place/)).toBeTruthy();
-    expect(screen.getByText(/exactly thirteen numbers/)).toBeTruthy();
+    // The two sun difficulties, stated without shorthand — a reader
+    // called the first draft cryptic.
+    expect(screen.getByText(/the sun does not travel at one steady\s*speed/)).toBeTruthy();
+    expect(screen.getByText(/the sun does not set at the same spot/)).toBeTruthy();
+    expect(screen.getByText(/how quickly the sky gets dark after\s*sunset/)).toBeTruthy();
+    expect(screen.getByText(/exactly thirteen of them/)).toBeTruthy();
   });
 });
 

--- a/src/components/book/thirteenNumbers.test.jsx
+++ b/src/components/book/thirteenNumbers.test.jsx
@@ -86,6 +86,16 @@ describe('the five pairs, from the constants', () => {
   });
 });
 
+describe('the window opening', () => {
+  it('starts where the reader stands and derives the need', () => {
+    page();
+    expect(screen.getByText(/Start at the window/)).toBeTruthy();
+    expect(screen.getByText(/how dark it will be,\s*and when/)).toBeTruthy();
+    expect(screen.getByText(/does not set in one place/)).toBeTruthy();
+    expect(screen.getByText(/exactly thirteen numbers/)).toBeTruthy();
+  });
+});
+
 describe('the two odd ones', () => {
   it('states the stakes of each: the gap transfer, and the heaviest lever', () => {
     page();

--- a/src/components/sky/SkyPage.jsx
+++ b/src/components/sky/SkyPage.jsx
@@ -300,9 +300,9 @@ export default function SkyPage() {
 
 const MODERN_VERDICT_PROSE = {
   likely:
-    'a crescent could well be caught — it passed 7° before sunset and is still up after it.',
+    'a crescent is there to look for — past 7° before sunset and still up after it.',
   challenging:
-    'borderline — 7° arrives only between sunset and moonset, so the thinnest of crescents.',
+    'barely past the gate — 7° arrives only between sunset and moonset, the thinnest of crescents.',
   impossible: 'no sighting possible — the moon sets before opening 7° from the sun.',
   'no-crescent-yet': 'no crescent exists yet — conjunction falls after sunset this evening.',
   'daylight-only':
@@ -310,6 +310,17 @@ const MODERN_VERDICT_PROSE = {
   'not-crescent-night': 'not a first-crescent evening.',
   indeterminate: 'no moonset found near this sunset to test against.',
 };
+
+/** Yallop's bands, in words (NAO TN 69). */
+const YALLOP_PROSE = {
+  A: 'easily visible to the naked eye',
+  B: 'visible to the naked eye in perfect conditions',
+  C: 'optical aid may be needed to find it, then the eye can hold it',
+  D: 'optical aid needed throughout — the eye alone will not catch it',
+  E: 'not visible even with a telescope',
+  F: 'not visible — below the Danjon limit',
+};
+const yallopSighted = (code) => code === 'A' || code === 'B' || code === 'C';
 
 /**
  * The modern check, for information: does the crescent actually exist
@@ -331,7 +342,12 @@ function ModernCheck({ eve, his }) {
     const t = new Date(d.getTime() + offset * 3600000);
     return `${t.getUTCDate()} ${MONTHS[t.getUTCMonth()]}, ${formatClock(t.getUTCHours() + t.getUTCMinutes() / 60)}`;
   };
-  const modernSighted = check.verdict === 'likely' || check.verdict === 'challenging';
+  // The full check trumps the gate for "would an eye catch it": bands
+  // A-C count as sightable, D-F as not. Without a q value (moon down by
+  // dusk, or no crescent), the coarse gate stands in.
+  const modernSighted = check.yallop
+    ? yallopSighted(check.yallop.code)
+    : check.verdict === 'likely' || check.verdict === 'challenging';
   const comparable =
     his.isCandidate && check.verdict !== 'not-crescent-night' && check.verdict !== 'indeterminate';
   return (
@@ -356,8 +372,34 @@ function ModernCheck({ eve, his }) {
           }${check.windowMinutes != null ? ` — a ${check.windowMinutes} min window` : ''}`}
         />
       </div>
+      {check.yallop && (
+        <div className="mt-2 grid gap-2 sm:grid-cols-3">
+          <Readout
+            title="Best moment (Yallop)"
+            value={formatClock(check.yallop.bestUtc + offset)}
+            note={`sunset + 4/9 of the ${check.yallop.lagMinutes}-minute lag to moonset`}
+          />
+          <Readout
+            title="Arc of vision vs crescent width"
+            value={`${check.yallop.arcv.toFixed(1)}° over ${check.yallop.wPrime.toFixed(2)}′`}
+            note="the moon's height above the sun then, against the lune's thickness"
+          />
+          <Readout
+            title="q-test"
+            value={`q = ${check.yallop.q.toFixed(3)} — band ${check.yallop.code}`}
+            note={YALLOP_PROSE[check.yallop.code]}
+          />
+        </div>
+      )}
       <p className="mt-3 text-xs leading-relaxed">
         <strong>Modern reading:</strong> {MODERN_VERDICT_PROSE[check.verdict]}
+        {check.yallop && (
+          <>
+            {' '}
+            The full q-test says the crescent is <strong>{YALLOP_PROSE[check.yallop.code]}</strong>{' '}
+            (band {check.yallop.code}).
+          </>
+        )}
         {comparable && (
           <>
             {' '}
@@ -369,9 +411,11 @@ function ModernCheck({ eve, his }) {
         )}
       </p>
       <p className="mt-2 text-[10px] leading-relaxed text-[var(--color-text-secondary)]">
-        The check is elongation-only. Full modern forecasts (Yallop, Odeh) also weigh the
-        crescent's width and its height above the sun, so "could well be caught" here is the
-        generous end of modern practice.
+        Two criteria: the 7° gate asks whether a crescent <em>exists</em> to look for; Yallop's
+        q-test — the criterion fitted to 295 recorded first sightings (NAO TN 69, 1997), weighing
+        the moon's height above the sun against the crescent's width at the best moment of dusk —
+        asks whether an eye would <em>catch</em> it, in bands A (easy) through F (below the Danjon
+        limit). Cloud, dust and haze remain outside every criterion.
       </p>
     </section>
   );

--- a/src/components/sky/SkyPage.jsx
+++ b/src/components/sky/SkyPage.jsx
@@ -37,6 +37,7 @@ import { skyPosition, jdAt } from '../../lib/skyView';
 import { modernSunLongitude, modernMoonPosition, angularDifference } from '../../lib/modernAstronomy';
 import { sunsetUtcHours, israelUtcOffsetHours, formatClock, RAMBAM_REFERENCE } from '../../lib/localObserver';
 import { nextSightingNight } from '../../lib/sightingNight';
+import { assessEvening, DANJON_LIMIT_DEG } from '../../lib/moonVisibility';
 
 const OBSERVER = { latitude: 31.78, longitude: 35.2137 };
 const EXAMPLE_DAYS = 29;
@@ -103,6 +104,27 @@ function sceneFor(days, utcHours, real) {
     belt.push({ lambda, ...skyPosition(lambda, 0, jd, OBSERVER) });
   }
   return { date, calc, jd, sun, moon, belt, delta, shown };
+}
+
+/**
+ * KH 17's verdict, gated to sighting-shaped nights. Near conjunction
+ * the chain's arcs wrap and the verdict is meaningless — a reader
+ * caught it saying "could be seen" with the moon drawn ON the sun.
+ * Only sighting-shaped nights get a verdict.
+ */
+function hisVerdictFor(calc) {
+  const gap = calc.moon.elongation;
+  const arc = calc.moon.keshetHaReiyah;
+  const isCandidate = gap > 2.5 && gap < 40 && arc > 0 && arc < 40;
+  return {
+    gap,
+    isCandidate,
+    verdict: isCandidate
+      ? calc.moon.visibilityVerdict === 'visible'
+        ? 'could be seen'
+        : 'not seen'
+      : null,
+  };
 }
 
 export default function SkyPage() {
@@ -208,8 +230,8 @@ export default function SkyPage() {
               className="accent-[var(--color-accent)]"
             />
             <span>
-              <strong>Show the real sky</strong> — swap his positions for modern ones (Meeus).
-              The verdict readout stays his either way; the real moon never enters it.
+              <strong>Show the actual sky</strong> — swap his positions for modern ones (Meeus).
+              The verdict readout stays his either way; the actual moon never enters it.
             </span>
           </label>
           <label className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
@@ -232,37 +254,25 @@ export default function SkyPage() {
         {/* ── readouts ── */}
         <div className="mt-4 grid gap-2 sm:grid-cols-3">
           <Readout
-            title={real ? 'The real sun' : 'His sun'}
+            title={real ? 'Sun (actual)' : 'Sun (Rambam)'}
             value={`${formatDms(scene.shown.sunLon)} on the circle`}
             note={`altitude ${scene.sun.altitude.toFixed(1)}°, azimuth ${scene.sun.azimuth.toFixed(0)}° — ${scene.sun.altitude < -0.8 ? 'below the horizon' : 'setting'}${real ? ` · his sits ${scene.delta.sun >= 0 ? '+' : ''}${scene.delta.sun.toFixed(2)}° from this` : ''}`}
           />
           <Readout
-            title={real ? 'The real moon' : 'His moon'}
+            title={real ? 'Moon (actual)' : 'Moon (Rambam)'}
             value={`${formatDms(scene.shown.moonLon)} — the ${moonSign}${ordinalSuffix(moonSign)} sign`}
             note={`altitude ${scene.moon.altitude.toFixed(1)}°, azimuth ${scene.moon.azimuth.toFixed(0)}°${scene.moon.altitude < 0 ? ' — below the horizon tonight' : ''}${real ? ` · his sits ${scene.delta.moon >= 0 ? '+' : ''}${scene.delta.moon.toFixed(2)}° from this` : ''}`}
           />
           {(() => {
-            // Near conjunction the chain's arcs wrap and the verdict is
-            // meaningless — a reader caught it saying "could be seen"
-            // with the moon drawn ON the sun. Only sighting-shaped
-            // nights get a verdict.
-            const gap = scene.calc.moon.elongation;
-            const arc = scene.calc.moon.keshetHaReiyah;
-            const isCandidate = gap > 2.5 && gap < 40 && arc > 0 && arc < 40;
+            const his = hisVerdictFor(scene.calc);
             return (
               <Readout
                 title="Verdict that evening"
-                value={
-                  isCandidate
-                    ? scene.calc.moon.visibilityVerdict === 'visible'
-                      ? 'could be seen'
-                      : 'not seen'
-                    : 'not a sighting night'
-                }
+                value={his.isCandidate ? his.verdict : 'not a sighting night'}
                 note={
-                  isCandidate
+                  his.isCandidate
                     ? "KH 17's rule, from the chain the book builds"
-                    : `the moon is ${gap > 180 ? (360 - gap).toFixed(1) : gap.toFixed(1)}° from the sun — nowhere near a first crescent`
+                    : `the moon is ${his.gap > 180 ? (360 - his.gap).toFixed(1) : his.gap.toFixed(1)}° from the sun — nowhere near a first crescent`
                 }
               />
             );
@@ -279,9 +289,91 @@ export default function SkyPage() {
           clock held and the three speeds of the book appear: the grid drifts a degree a night,
           the sun barely moves against your window, the moon runs.
         </p>
+
+        <ModernCheck eve={scene.date} his={hisVerdictFor(scene.calc)} />
+
         <SiteCredit />
       </main>
     </div>
+  );
+}
+
+const MODERN_VERDICT_PROSE = {
+  likely:
+    'a crescent could well be caught — it passed 7° before sunset and is still up after it.',
+  challenging:
+    'borderline — 7° arrives only between sunset and moonset, so the thinnest of crescents.',
+  impossible: 'no sighting possible — the moon sets before opening 7° from the sun.',
+  'no-crescent-yet': 'no crescent exists yet — conjunction falls after sunset this evening.',
+  'daylight-only':
+    'a daytime window only — the moon is past 7° but sets before the sun. Testimony of a sighting made while it is still day is admissible — the court itself sanctifies on one (KH 2:9) — but a crescent this thin defeats the naked eye against a daylit sky.',
+  'not-crescent-night': 'not a first-crescent evening.',
+  indeterminate: 'no moonset found near this sunset to test against.',
+};
+
+/**
+ * The modern check, for information: does the crescent actually exist
+ * by sunset, has it actually opened 7° (the Danjon limit), and does the
+ * moon actually set late enough to leave a window — real Jerusalem
+ * sunset, real moonset, Meeus positions throughout. COMPARISON ONLY:
+ * the verdict above stays KH 17's, and nothing here feeds it.
+ */
+function ModernCheck({ eve, his }) {
+  // Keyed on the timestamp: eveningOf builds a fresh Date each render.
+  const check = useMemo(() => assessEvening(eve, OBSERVER), [eve.getTime()]); // eslint-disable-line react-hooks/exhaustive-deps
+  if (!check) return null;
+  const offset = israelUtcOffsetHours(eve);
+  const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  // Same clock convention as the sunset slider above: UTC plus Israel's
+  // legal offset, applied even to historical dates.
+  const fmtInstant = (d) => {
+    if (!d) return '—';
+    const t = new Date(d.getTime() + offset * 3600000);
+    return `${t.getUTCDate()} ${MONTHS[t.getUTCMonth()]}, ${formatClock(t.getUTCHours() + t.getUTCMinutes() / 60)}`;
+  };
+  const modernSighted = check.verdict === 'likely' || check.verdict === 'challenging';
+  const comparable =
+    his.isCandidate && check.verdict !== 'not-crescent-night' && check.verdict !== 'indeterminate';
+  return (
+    <section className="mt-8 rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-4">
+      <h2 className="text-sm font-bold">Would it actually be seen? — the modern check, Jerusalem</h2>
+      <p className="mt-1 text-xs leading-relaxed text-[var(--color-text-secondary)]">
+        Everything above draws positions. This box asks the modern question directly for this
+        evening: has conjunction actually happened, has the moon opened{' '}
+        {DANJON_LIMIT_DEG}° from the sun — the <strong>Danjon limit</strong>, the least
+        separation at which a naked eye has ever caught a crescent — and does the moon set late
+        enough after the sun to leave a window. Real sunset, real moonset, Meeus positions.
+        For information only: the verdict above stays KH 17's, and none of this feeds it.
+      </p>
+      <div className="mt-3 grid gap-2 sm:grid-cols-3">
+        <Readout title="Conjunction (true molad)" value={fmtInstant(check.conjunction)} note="the actual sun-moon lineup, not the mean molad" />
+        <Readout title={`Opens ${DANJON_LIMIT_DEG}° (Danjon limit)`} value={fmtInstant(check.sevenDeg)} note="~11-16 hours after conjunction, by the moon's speed" />
+        <Readout
+          title="Elongation at sunset"
+          value={`${check.elongationAtSunset.toFixed(1)}°`}
+          note={`sunset ${formatClock(check.sunsetUtc + offset)}, moonset ${
+            check.moonsetUtc != null ? formatClock(check.moonsetUtc + offset) : '—'
+          }${check.windowMinutes != null ? ` — a ${check.windowMinutes} min window` : ''}`}
+        />
+      </div>
+      <p className="mt-3 text-xs leading-relaxed">
+        <strong>Modern reading:</strong> {MODERN_VERDICT_PROSE[check.verdict]}
+        {comparable && (
+          <>
+            {' '}
+            KH 17 above says <strong>{his.verdict}</strong> —{' '}
+            {modernSighted === (his.verdict === 'could be seen')
+              ? 'the two agree this evening.'
+              : 'the two split this evening. His moon carries about a degree of error and the criteria differ — his arc of sighting against a bare elongation limit — so borderline evenings can land on opposite sides.'}
+          </>
+        )}
+      </p>
+      <p className="mt-2 text-[10px] leading-relaxed text-[var(--color-text-secondary)]">
+        The check is elongation-only. Full modern forecasts (Yallop, Odeh) also weigh the
+        crescent's width and its height above the sun, so "could well be caught" here is the
+        generous end of modern practice.
+      </p>
+    </section>
   );
 }
 
@@ -447,7 +539,7 @@ function SkyFigure({ scene, real }) {
           <g>
             <circle cx={x(scene.sun.azimuth)} cy={y(scene.sun.altitude)} r="11" fill="var(--color-gold)" fillOpacity={scene.sun.altitude < 0 ? 0.45 : 0.9} />
             <text x={x(scene.sun.azimuth)} y={y(scene.sun.altitude) + 24} fontSize="11" textAnchor="middle" fill="var(--color-gold)">
-              {real ? 'the real sun' : 'his sun'}
+              {real ? 'Sun (actual)' : 'Sun (Rambam)'}
             </text>
           </g>
         )}
@@ -471,7 +563,7 @@ function SkyFigure({ scene, real }) {
                 <path d={d} fill="var(--color-silver)" fillOpacity={dim} />
               </g>
               <text x={mxp} y={myp - 12} fontSize="11" textAnchor="middle" fill="var(--color-silver)">
-                {real ? 'the real moon' : 'his moon'}
+                {real ? 'Moon (actual)' : 'Moon (Rambam)'}
               </text>
             </g>
           );

--- a/src/components/sky/SkyPage.jsx
+++ b/src/components/sky/SkyPage.jsx
@@ -417,7 +417,7 @@ function ModernCheck({ eve, his }) {
         asks whether an eye would <em>catch</em> it, in bands A (easy) through F (below the Danjon
         limit). Cloud, dust and haze remain outside every criterion. Jerusalem stands here for
         the whole Land, the way the Rambam's own single reference does (KH 11:17) — checked
-        across Israel's full span, Metula to Eilat, the q-test moves by at most about one band,
+        across the classical span, from Dan to Beersheba, the q-test moves by at most one band,
         and only on knife-edge evenings, with the south slightly favoured; on any clear verdict
         every city agrees.
       </p>

--- a/src/components/sky/SkyPage.jsx
+++ b/src/components/sky/SkyPage.jsx
@@ -415,7 +415,11 @@ function ModernCheck({ eve, his }) {
         q-test — the criterion fitted to 295 recorded first sightings (NAO TN 69, 1997), weighing
         the moon's height above the sun against the crescent's width at the best moment of dusk —
         asks whether an eye would <em>catch</em> it, in bands A (easy) through F (below the Danjon
-        limit). Cloud, dust and haze remain outside every criterion.
+        limit). Cloud, dust and haze remain outside every criterion. Jerusalem stands here for
+        the whole Land, the way the Rambam's own single reference does (KH 11:17) — checked
+        across Israel's full span, Metula to Eilat, the q-test moves by at most about one band,
+        and only on knife-edge evenings, with the south slightly favoured; on any clear verdict
+        every city agrees.
       </p>
     </section>
   );

--- a/src/components/sky/skyPage.test.jsx
+++ b/src/components/sky/skyPage.test.jsx
@@ -30,10 +30,11 @@ const page = () =>
   );
 
 describe('the page', () => {
-  it('renders both bodies, labelled as his', async () => {
+  it('renders both bodies, labelled as the Rambam\'s', async () => {
     page();
-    expect(await screen.findByText('his sun')).toBeTruthy();
-    expect(screen.getByText('his moon')).toBeTruthy();
+    // The label appears on the drawn body and as a readout title.
+    expect((await screen.findAllByText('Sun (Rambam)')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Moon (Rambam)').length).toBeGreaterThan(0);
   });
 
   it('carries the regime note — positions his, frame modern', () => {
@@ -76,31 +77,54 @@ describe("his worked evening's scene, numerically", () => {
   });
 });
 
-describe('the real-sky toggle', () => {
+describe('the actual-sky toggle', () => {
   it('swaps the drawn bodies to modern positions, relabelled', async () => {
     page();
-    expect(await screen.findByText('his sun')).toBeTruthy();
-    const toggle = screen.getByText(/Show the real sky/).closest('label').querySelector('input');
+    expect((await screen.findAllByText('Sun (Rambam)')).length).toBeGreaterThan(0);
+    const toggle = screen.getByText(/Show the actual sky/).closest('label').querySelector('input');
     fireEvent.click(toggle);
-    expect(await screen.findByText('the real sun')).toBeTruthy();
-    expect(screen.getByText('the real moon')).toBeTruthy();
+    expect((await screen.findAllByText('Sun (actual)')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Moon (actual)').length).toBeGreaterThan(0);
     // The deltas are on the readouts, so the gap between his sky and the
     // real one is a number, not an impression.
     expect(screen.getAllByText(/his sits [+−-]?\d+\.\d+° from this/).length).toBe(2);
   });
 
-  it("keeps the verdict his — the real moon never enters it", () => {
+  it("keeps the verdict his — the actual moon never enters it", () => {
     page();
     expect(screen.getByText(/verdict readout stays his either way/)).toBeTruthy();
   });
 
   it('labels the belt with names as well as numbers', async () => {
     page();
-    await screen.findByText('his sun');
+    await screen.findAllByText('Sun (Rambam)');
     // At least one transliterated name on the gold line, beneath its number.
     const names = ['Taleh', 'Shor', 'Teomim', 'Sartan', 'Aryeh', 'Betulah', 'Moznayim', 'Akrav', 'Keshet', "G'di", "D'li", 'Dagim'];
     const found = names.filter((n) => screen.queryAllByText(n).length > 0);
     expect(found.length).toBeGreaterThan(0);
+  });
+});
+
+describe('the modern check panel', () => {
+  it('is on the page, with its facts and its comparison-only stance', async () => {
+    page();
+    expect(await screen.findByText(/Would it actually be seen/)).toBeTruthy();
+    expect(screen.getByText('Conjunction (true molad)')).toBeTruthy();
+    expect(screen.getByText(/Opens 7° \(Danjon limit\)/)).toBeTruthy();
+    expect(screen.getByText('Elongation at sunset')).toBeTruthy();
+    // The stance: information only, never feeding the verdict.
+    expect(screen.getByText(/none of this feeds it/)).toBeTruthy();
+    // And the honesty note about the criterion's generosity.
+    expect(screen.getByText(/Yallop, Odeh/)).toBeTruthy();
+  });
+
+  it("agrees with KH 17 on his worked evening, and says so", async () => {
+    // Day 29 (the default): his verdict is "visible", and the modern
+    // check finds a real crescent with a window (pinned numerically in
+    // moonVisibility.test.js) — so the comparison line reports agreement.
+    page();
+    expect(await screen.findByText(/Modern reading:/)).toBeTruthy();
+    expect(screen.getByText(/the two agree this evening/)).toBeTruthy();
   });
 });
 
@@ -195,7 +219,7 @@ describe("the moon's drawn phase", () => {
 
   it('renders as a path inside a rotated group, not a plain disc', async () => {
     const { container } = page();
-    await screen.findByText('his moon');
+    await screen.findAllByText('Moon (Rambam)');
     const rotated = [...container.querySelectorAll('g[transform*="rotate"] path')];
     expect(rotated.length).toBeGreaterThan(0);
   });

--- a/src/components/sky/skyPage.test.jsx
+++ b/src/components/sky/skyPage.test.jsx
@@ -114,16 +114,18 @@ describe('the modern check panel', () => {
     expect(screen.getByText('Elongation at sunset')).toBeTruthy();
     // The stance: information only, never feeding the verdict.
     expect(screen.getByText(/none of this feeds it/)).toBeTruthy();
-    // And the honesty note about the criterion's generosity.
-    expect(screen.getByText(/Yallop, Odeh/)).toBeTruthy();
+    // Both criteria present: the existence gate and the catchability test.
+    expect(screen.getByText(/fitted to 295 recorded first sightings/)).toBeTruthy();
+    expect(screen.getByText(/Best moment \(Yallop\)/)).toBeTruthy();
   });
 
   it("agrees with KH 17 on his worked evening, and says so", async () => {
-    // Day 29 (the default): his verdict is "visible", and the modern
-    // check finds a real crescent with a window (pinned numerically in
-    // moonVisibility.test.js) — so the comparison line reports agreement.
+    // Day 29 (the default): his verdict is "visible", and Yallop's
+    // q-test puts the crescent in a naked-eye band (pinned numerically
+    // in moonVisibility.test.js) — the comparison line reports agreement.
     page();
     expect(await screen.findByText(/Modern reading:/)).toBeTruthy();
+    expect(screen.getByText(/q = −?-?\d\.\d{3} — band [ABC]/)).toBeTruthy();
     expect(screen.getByText(/the two agree this evening/)).toBeTruthy();
   });
 });

--- a/src/content/book/ch13.js
+++ b/src/content/book/ch13.js
@@ -120,7 +120,7 @@ export default {
       body: [
         'Now the answers themselves — **the fix** to apply. The Rambam lists it for every ten degrees of course, from nothing up to a maximum and back down to nothing.',
         'In the text it is nineteen lines of prose and hard to see any shape in. Plotted, it is obviously a smooth arch: zero at the start, rising to **1° 59\'** when the course is 90 degrees, falling back to zero at 180.',
-        'Two degrees, at most. That is the entire size of the difference between the pretend sun and the real one — small, but far too big to ignore when the whole question turns on a few degrees of angle.',
+        'Two degrees, at most. That is the entire size of the difference between the pretend sun and the real one — small, but far too big to ignore when the whole question turns on a few degrees of angle. And it lands where it hurts: chapter 17\'s gap is the moon\'s position minus the sun\'s, so every arcminute the sun is off moves the gap by that same arcminute — and the gap\'s verdict thresholds sit only single degrees apart.',
       ],
       interactive: 'correction-table',
     },

--- a/src/content/book/ch16.js
+++ b/src/content/book/ch16.js
@@ -130,6 +130,7 @@ export default {
         'The Rambam names them for what the moon does there. At one, the moon is crossing from below the sun\'s track to above it — he calls that the **head** (ראש); think of it as **the up-crossing**. Half a circle away it crosses back down: the **tail** (זנב), or **the down-crossing**.',
         'At either crossing the moon sits exactly on the sun\'s track and has no height at all. Between them it climbs to five degrees and comes back down. So if you know where the up-crossing is, and where the moon is, you know how high it must be — which is the calculation the rest of the chapter performs.',
         'And because the two are always half a circle apart, knowing one gives you the other for free. Seven signs along, at the same degree.',
+        'The crossings also answer a question you may never have thought to ask: **why is there no eclipse of the sun every month?** The moon passes the sun every month — but almost always sails above or below it; five degrees of height is ten of the sun\'s own widths. Only when the meeting happens to fall near a crossing do the two truly line up. (He does not raise eclipses here; the observation is this book\'s.)',
       ],
     },
 

--- a/src/content/book/ch17.js
+++ b/src/content/book/ch17.js
@@ -99,12 +99,12 @@ export default {
   sections: [
     {
       id: 'the-two-numbers',
-      heading: 'Two numbers, and what they are called',
+      heading: 'Two numbers, and what they are called — steps 3 and 4 of the chain',
       source: 'KH 17:1',
       nodeId: 'arc',
       body: [
         'The chapter opens by naming the two things it will work with, and both are already in your hands.',
-        'Subtract the sun\'s position from the moon\'s. That is **the gap** — how far the moon has pulled clear of the sun along the sun\'s own road. The text calls it the *first longitude*. It is the single most important number in the chapter, and you have been computing it since chapter 15 under a different name.',
+        'Subtract the sun\'s position from the moon\'s. That is **the gap** — how far the moon has pulled clear of the sun along the sun\'s own road. The text calls it the *first longitude* — **אורך ראשון**. It is the single most important number in the chapter, and you have been computing it since chapter 15 under a different name.',
         'The moon\'s height off the sun\'s road, from chapter 16, comes in as **the height** — the text\'s *first latitude*, **רוחב ראשון**. Keep the direction with it; north and south behave differently from here on.',
         'The Rambam says to have both "at hand". He means it — they get used repeatedly, including right at the end, long after several rounds of adjustment have produced other numbers that look similar and are not the same.',
       ],
@@ -162,7 +162,7 @@ export default {
 
     {
       id: 'by-sign',
-      heading: 'The corrections that depend on which sign the moon is in',
+      heading: 'The corrections that depend on which sign the moon is in — steps 5 and 6',
       source: 'KH 17:5',
       nodeId: 'arc',
       body: [
@@ -177,7 +177,7 @@ export default {
 
     {
       id: 'the-slice',
-      heading: 'The slice — one shape, not a list',
+      heading: 'The slice — one shape, not a list — step 7',
       source: 'KH 17:10',
       nodeId: 'arc',
       body: [
@@ -190,7 +190,7 @@ export default {
 
     {
       id: 'the-stretch',
-      heading: 'The stretch — not the slice again',
+      heading: 'The stretch — not the slice again — step 8',
       source: 'KH 17:12',
       nodeId: 'arc',
       body: [
@@ -202,12 +202,12 @@ export default {
 
     {
       id: 'three-more',
-      heading: 'The finish',
+      heading: 'The finish — steps 9 and 10',
       source: 'KH 17:10',
       nodeId: 'arc',
       body: [
         'One step remains, and then the whole chain runs below — every step showing what it is built from. Keep the tally straight by what each touch *produces*: the gap began as the *first longitude*; standing-on-the-ground made the *second*; the slice made the *third*; the stretch, the *fourth*.',
-        'Then, finally, go back to the **original** height — the one you were told to keep at hand, before any adjustment — take **two thirds** of it, always two thirds for the land of Israel, and apply that to the gap: north adds, south takes away.',
+        'Then, finally, go back to the **original** height — the one you were told to keep at hand, before any adjustment — take **two thirds** of it, always two thirds for the land of Israel, and apply that to the gap: north adds, south takes away. Two thirds of a height that can reach five degrees is a swing of more than three degrees between a northern moon and a southern one — the heaviest single lever in the whole chain, on verdicts whose margins are often fractions of a degree.',
         'What comes out is **the final figure** — the *arc of sighting*, קשת הראייה. The verdict depends on it and nothing else.',
       ],
       interactive: 'visibility-chain',

--- a/src/content/book/ch17.js
+++ b/src/content/book/ch17.js
@@ -105,7 +105,7 @@ export default {
       body: [
         'The chapter opens by naming the two things it will work with, and both are already in your hands.',
         'Subtract the sun\'s position from the moon\'s. That is **the gap** — how far the moon has pulled clear of the sun along the sun\'s own road. The text calls it the *first longitude*. It is the single most important number in the chapter, and you have been computing it since chapter 15 under a different name.',
-        'The moon\'s height off the sun\'s road, from chapter 16, comes in as **the height** — the text\'s *first latitude*. Keep the direction with it; north and south behave differently from here on.',
+        'The moon\'s height off the sun\'s road, from chapter 16, comes in as **the height** — the text\'s *first latitude*, **רוחב ראשון**. Keep the direction with it; north and south behave differently from here on.',
         'The Rambam says to have both "at hand". He means it — they get used repeatedly, including right at the end, long after several rounds of adjustment have produced other numbers that look similar and are not the same.',
       ],
     },
@@ -135,9 +135,9 @@ export default {
       nodeId: 'arc',
       body: [
         'Before the adjustments start, one thing about the naming, because it is the single most confusing feature of this chapter and it is entirely an accident of vocabulary.',
-        'You are about to meet a **first longitude**, a **second longitude**, a **third longitude** and a **fourth longitude**. That sounds like four quantities to keep track of. It is not.',
+        'You are about to meet a **first longitude** (אורך ראשון), a **second longitude** (אורך שני), a **third longitude** (אורך שלישי) and a **fourth longitude** (אורך רביעי). That sounds like four quantities to keep track of. It is not.',
         '**It is one number, adjusted four times.** The gap between the sun and the moon is worked out once, and then nudged — for standing on the ground, for the moon\'s height, for how steeply the sky sets — and after each nudge the text calls it by the next number along: second, then third, then fourth. On the evening the Rambam works through, that single running number goes:',
-        '11° 27′ → 10° 27′ → 11° 28′ → 13° 46′ → and finally 11° 10′, which he calls the arc of sighting.',
+        '11° 27′ → 10° 27′ → 11° 28′ → 13° 46′ → and finally 11° 10′, which he calls the arc of sighting — קשת הראייה.',
         'The last one gets a name of its own instead of being called the fifth, but it is still the same running number, and it is the one the verdict is read from.',
         'So when the text says "the third longitude", read it as **"the gap, after two adjustments"**. Nothing is being introduced; something is being corrected. Hold on to the one number and the chapter becomes a list of four things done to it.',
       ],
@@ -167,8 +167,8 @@ export default {
       nodeId: 'arc',
       body: [
         'Here is the promise chapter 11 made coming due. Back then, the question was why the Rambam bothers naming the twelve signs when a position is already a number. This is the answer.',
-        'The first correction takes minutes off the gap, and **how many depends on the sign the moon is in**: 59 minutes in the 1st sign, a full degree in the 2nd, 58 in the 3rd, down to 34 in the 7th, and back up again. Twelve signs, twelve numbers. The result is the gap after one adjustment — the *second longitude*.',
-        'The second does the same to the height, with its own set of twelve — 9 minutes in the 1st sign, 10 in the 2nd, up to 46 in the 7th. And here the direction matters: if the moon is north of the sun\'s road you take the correction off, if south you add it on. That gives the height after its one adjustment — the *second latitude*.',
+        'The first correction takes minutes off the gap, and **how many depends on the sign the moon is in**: 59 minutes in the 1st sign, a full degree in the 2nd, 58 in the 3rd, down to 34 in the 7th, and back up again. Twelve signs, twelve numbers. The result is the gap after one adjustment — the *second longitude*, **אורך שני**.',
+        'The second does the same to the height, with its own set of twelve — 9 minutes in the 1st sign, 10 in the 2nd, up to 46 in the 7th. And here the direction matters: if the moon is north of the sun\'s road you take the correction off, if south you add it on. That gives the height after its one adjustment — the *second latitude*, **רוחב שני**.',
         'Neither table is a list of made-up numbers. Both are tracking the same thing — how the parallax shift breaks down into sideways and vertical parts, which depends on the angle the belt makes with the horizon, which depends on which stretch of the belt is setting. The sign is a shorthand for that angle.',
         'The civil-date trick from the early exits works here too, sign by sign. On sighting nights the moon\'s sign steps through the year two months at a time: the 1st sign belongs to the nights of **March and April**, the 2nd to April and May, and so on round to the 12th in February and March. So each row of these tables is, in practice, the row for one stretch of the calendar — the figure below shows the months beside each sign.',
       ],
@@ -182,8 +182,8 @@ export default {
       nodeId: 'arc',
       body: [
         'The first of the remaining steps takes **a slice of the adjusted height**, and which fraction to take depends on one thing only: **where the moon stands on the circle**. The pattern is worth seeing whole. Near the starts of the 1st and 7th signs the slice is at its biggest, **two fifths**. Step away and it shrinks by stages — a third, a quarter, a fifth, a sixth, a twelfth, a twenty-fourth — until, in a small band straddling the starts of the 4th and 10th signs, it is **nothing at all**, and the step is skipped. Then it grows back by the same stages, and the second half of the circle mirrors the first exactly.',
-        'Those two special points should sound familiar: they are the turning points from chapter 11 — where the sun\'s road runs level with the equator. Where the road is level, the moon\'s height off it stays purely sideways and none of it tips along the road; where the road crosses at its steepest slant, near the 1st and 7th signs, the most height leaks into the along-the-road direction. (That reading is this book\'s; he states the fractions and gives no reason.) On sighting nights it means the slice matters most in spring and autumn and vanishes near midsummer and midwinter. The Rambam calls the result the *circuit of the moon*; call it **the slice**.',
-        '**The third longitude** is the gap after the slice is applied — step 7 of the finishing card below. Which way the slice goes is the rule the figure above shows: it depends on which half of the sky the moon is in and which side of the road it sits.',
+        'Those two special points should sound familiar: they are the turning points from chapter 11 — where the sun\'s road runs level with the equator. Where the road is level, the moon\'s height off it stays purely sideways and none of it tips along the road; where the road crosses at its steepest slant, near the 1st and 7th signs, the most height leaks into the along-the-road direction. (That reading is this book\'s; he states the fractions and gives no reason.) On sighting nights it means the slice matters most in spring and autumn and vanishes near midsummer and midwinter. The Rambam calls the result the *circuit of the moon* — **מעגל הירח**; call it **the slice**.',
+        '**The third longitude** — **אורך שלישי** — is the gap after the slice is applied — step 7 of the finishing card below. Which way the slice goes is the rule the figure above shows: it depends on which half of the sky the moon is in and which side of the road it sits.',
       ],
       interactive: 'slice-shape',
     },
@@ -195,7 +195,7 @@ export default {
       nodeId: 'arc',
       body: [
         'One naming note first, because the short name misleads exactly once: this book calls the whole step **the stretch**, but it runs both ways — the gap is pulled longer over the slow-setting parts of the belt and let back shorter over the plunging ones. On many nights "the stretch" shrinks.',
-        '**The fourth longitude** is that number stretched or shrunk — step 8 — and this is *not* the slice again, though it sounds like it. The slice was a fraction of the **height**, brought in from a different measurement. Here the gap is scaled by a fraction **of itself**: depending on which sign **the moon** is in, add a sixth or a fifth of it, leave it alone, or subtract a fifth or a third. The reason is how steeply that part of the belt sets — a slow-setting stretch of sky makes each degree of gap worth more, so the number is stretched to match; a fast-setting stretch, the reverse. The same underlying fact as the early-exit halves, applied more finely.',
+        '**The fourth longitude** — **אורך רביעי** — is that number stretched or shrunk — step 8 — and this is *not* the slice again, though it sounds like it. The slice was a fraction of the **height**, brought in from a different measurement. Here the gap is scaled by a fraction **of itself**: depending on which sign **the moon** is in, add a sixth or a fifth of it, leave it alone, or subtract a fifth or a third. The reason is how steeply that part of the belt sets — a slow-setting stretch of sky makes each degree of gap worth more, so the number is stretched to match; a fast-setting stretch, the reverse. The same underlying fact as the early-exit halves, applied more finely.',
       ],
       interactive: 'stretch-shape',
     },
@@ -219,7 +219,7 @@ export default {
       source: 'KH 17:15',
       nodeId: 'verdict',
       body: [
-        'Nine degrees or less: not visible. More than fourteen: visible. Between the two, one more table — and it is the only place in the book where two numbers are weighed together.',
+        'Nine degrees or less: not visible. More than fourteen: visible. Between the two, one more table — the pass marks, **קיצי הראייה** — and it is the only place in the book where two numbers are weighed together.',
         'The rule is a sliding trade between the final figure and the original gap. A large final figure can carry a small gap, and a large gap can carry a small final figure. If the final figure is between 11 and 12 degrees the gap must reach 11; if it is between 13 and 14 the gap need only reach 9. The bigger one gets, the less is asked of the other.',
         'For his worked evening the arc comes to **11 degrees and 11 minutes** and the first longitude to **11 degrees and 27 minutes** — so the moon would have been seen.',
         'A note on the text here, because you may notice something odd if you read the English. The translation at 17:22 says the longitude was *ten* degrees 27 minutes, and then concludes it is "greater than **eleven**" — which ten is not.',

--- a/src/content/book/ch17.test.js
+++ b/src/content/book/ch17.test.js
@@ -551,8 +551,11 @@ describe('the adjustments name their outputs where they are made', () => {
     // tally the prose never showed; the ordinal now opens each bullet —
     // the third at the end of the slice section, the fourth beside the
     // stretch's own figure.
-    expect(body).toMatch(/\*\*The third longitude\*\* is the gap after the slice/);
-    expect(body).toMatch(/\*\*The fourth longitude\*\* is that number stretched or shrunk/);
+    // The ordinal still opens each bullet; the Hebrew name rides along so
+    // a reader can find the step in the Rambam's own text (a reader
+    // asked for exactly that link).
+    expect(body).toMatch(/\*\*The third longitude\*\* — \*\*אורך שלישי\*\* — is the gap after the slice/);
+    expect(body).toMatch(/\*\*The fourth longitude\*\* — \*\*אורך רביעי\*\* — is that number stretched or shrunk/);
     // A reader asked whether the fourth was "the same slice". It is not:
     // the slice is a fraction of the HEIGHT, the stretch a fraction of
     // the gap ITSELF — checked against the engine below.

--- a/src/lib/fixedYear.js
+++ b/src/lib/fixedYear.js
@@ -47,6 +47,81 @@ export function moladTishrei(year) {
 }
 
 /**
+ * The same molad, reached the way KH 6:12-14 teaches a reader to reach
+ * it — so a surface can show the work, not just the answer.
+ *
+ * From the anchor, count the elapsed years since year 1; take whole
+ * 19-year cycles, then classify the leftover years of the current cycle
+ * as common or leap (KH 6:11's positions 3, 6, 8, 11, 14, 17, 19); add
+ * each class's published remainder that many times, throwing away whole
+ * weeks as you go. Every step is returned as the day–hour–part triple
+ * the chapter does all its arithmetic in: `each × count = add`,
+ * accumulating through `running`. The last running total must equal
+ * moladTishrei's answer — the two routes differ only in bookkeeping —
+ * and fixedYear.test.js holds them to that.
+ */
+export function moladTishreiLadder(year) {
+  if (year < 1) throw new Error(`Hebrew year must be >= 1, got ${year}`);
+  const MONTH = SYNODIC_MONTH_PARTS;
+  const week = (parts) => ((parts % PARTS_PER_WEEK) + PARTS_PER_WEEK) % PARTS_PER_WEEK;
+  // An amount of parts as a d–h–p triple (days 0-6, an interval).
+  const amount = (parts) => {
+    const w = week(parts);
+    const day = Math.floor(w / PARTS_PER_DAY);
+    const rest = w - day * PARTS_PER_DAY;
+    return { day, hours: Math.floor(rest / PARTS_PER_HOUR), parts: rest % PARTS_PER_HOUR };
+  };
+  // A position in the week as a weekday triple (1 = Sunday … 7 = Shabbat).
+  const position = (parts) => {
+    const a = amount(parts);
+    return { ...a, day: a.day + 1 };
+  };
+
+  const elapsed = year - 1;
+  const cycles = Math.floor(elapsed / 19);
+  const remainderYears = elapsed % 19;
+  const leapPositions = [];
+  for (let i = 1; i <= remainderYears; i++) {
+    if (isHebrewLeapYear(cycles * 19 + i)) leapPositions.push(i);
+  }
+  const leapYears = leapPositions.length;
+  const commonYears = remainderYears - leapYears;
+
+  const CYCLE_REM = week(235 * MONTH);
+  const COMMON_REM = week(12 * MONTH);
+  const LEAP_REM = week(13 * MONTH);
+
+  let running = week(BAHARAD_PARTS_OFFSET);
+  const steps = [];
+  const push = (label, count, eachParts, ref) => {
+    const add = week(count * eachParts);
+    running = week(running + add);
+    steps.push({
+      label,
+      count,
+      each: amount(eachParts),
+      add: amount(add),
+      running: position(running),
+      ref,
+    });
+  };
+  push('19-year cycles', cycles, CYCLE_REM, 'KH 6:12');
+  push('common years', commonYears, COMMON_REM, 'KH 6:5');
+  push('leap years', leapYears, LEAP_REM, 'KH 6:5');
+
+  return {
+    anchor: position(week(BAHARAD_PARTS_OFFSET)),
+    cycles,
+    remainderYears,
+    commonYears,
+    leapYears,
+    leapPositions,
+    steps,
+    final: position(running),
+  };
+}
+
+/**
  * KH 7's four postponements, applied in order. Returns the weekday of
  * Rosh HaShanah (1 = Sunday … 7 = Shabbat) and which rules fired.
  *

--- a/src/lib/fixedYear.test.js
+++ b/src/lib/fixedYear.test.js
@@ -9,7 +9,7 @@
  * times.
  */
 import { describe, it, expect } from 'vitest';
-import { moladTishrei, roshHashanah, actualRoshHashanahDay, yearShape } from './fixedYear';
+import { moladTishrei, moladTishreiLadder, roshHashanah, actualRoshHashanahDay, yearShape } from './fixedYear';
 import { isHebrewLeapYear } from '../engine/fixedCalendar/months';
 
 describe('the four postponements reproduce the real calendar', () => {
@@ -104,5 +104,43 @@ describe('the shape of the year (KH 8)', () => {
         : { 2: 'lacking', 3: 'in-order', 4: 'complete' }[between];
       expect(shape.kind, `year ${year}, between ${between}`).toBe(expected);
     }
+  });
+});
+
+describe('the ladder shows the work and reaches the same rung (KH 6:12-14)', () => {
+  it('starts at BaHaRaD and adds the published remainders', () => {
+    const l = moladTishreiLadder(5786);
+    expect(l.anchor).toEqual({ day: 2, hours: 5, parts: 204 });
+    // The three "each" triples ARE his published remainders — derived
+    // here from the constants, matching the numbers of KH 6:5 and 6:12.
+    expect(l.steps[0].each).toEqual({ day: 2, hours: 16, parts: 595 });
+    expect(l.steps[1].each).toEqual({ day: 4, hours: 8, parts: 876 });
+    expect(l.steps[2].each).toEqual({ day: 5, hours: 21, parts: 589 });
+  });
+
+  it('classifies 5786 in its cycle correctly', () => {
+    const l = moladTishreiLadder(5786);
+    // 5785 elapsed years = 304 cycles + 9; leap among the first nine
+    // positions of a cycle are 3, 6 and 8.
+    expect(l.cycles).toBe(304);
+    expect(l.remainderYears).toBe(9);
+    expect(l.leapPositions).toEqual([3, 6, 8]);
+    expect(l.commonYears).toBe(6);
+  });
+
+  it('its last rung equals moladTishrei, across eras', () => {
+    for (const year of [1, 2, 19, 20, 4938, 5786, 5787, 6000, 7000]) {
+      expect(moladTishreiLadder(year).final, `year ${year}`).toEqual(moladTishrei(year));
+    }
+    for (let year = 5770; year <= 5810; year++) {
+      expect(moladTishreiLadder(year).final, `year ${year}`).toEqual(moladTishrei(year));
+    }
+  });
+
+  it('year 1 is the bare anchor: zero of everything added', () => {
+    const l = moladTishreiLadder(1);
+    expect(l.cycles).toBe(0);
+    expect(l.remainderYears).toBe(0);
+    expect(l.final).toEqual({ day: 2, hours: 5, parts: 204 });
   });
 });

--- a/src/lib/moonVisibility.js
+++ b/src/lib/moonVisibility.js
@@ -1,0 +1,173 @@
+/**
+ * A modern first-crescent visibility check — COMPARISON ONLY.
+ *
+ * ═══════════════════════════════════════════════════════════════════
+ *  REGIME TAG: **modern** — real astronomy, NOT the Rambam
+ *  SURFACE CATEGORY: internal lib (comparison only)
+ * ═══════════════════════════════════════════════════════════════════
+ *
+ * The engine's verdict is KH 17's and nothing else; this module exists
+ * so a surface can put the modern question beside it: has conjunction
+ * actually happened, has the moon actually opened 7° from the sun (the
+ * Danjon limit — the least elongation at which a naked eye has ever
+ * caught a crescent), and does the moon actually set late enough after
+ * the sun to leave a window? Nothing here may feed a verdict.
+ *
+ * Everything is built from the two comparison modules that already
+ * exist: modernAstronomy's Meeus sun and moon (good to ~0.05° for the
+ * moon, so times found by inverting it carry ~5-10 minutes), and
+ * skyView's frame conversion for the moonset search.
+ *
+ * The criterion is deliberately elongation-only. A full modern sighting
+ * forecast (Yallop, Odeh) also weighs crescent width and the moon's
+ * altitude above the sun; "likely" here is the generous end of modern
+ * practice, and the surfaces say so.
+ *
+ * Cross-checked in moonVisibility.test.js against an independently
+ * generated table (Meeus ch. 49 conjunctions verified against
+ * timeanddate.com).
+ */
+import { modernSunLongitude, modernMoonPosition } from './modernAstronomy';
+import { skyPosition, jdAt } from './skyView';
+import { sunsetUtcHours } from './localObserver';
+
+/** The Danjon limit: least sun-moon elongation ever sighted naked-eye. */
+export const DANJON_LIMIT_DEG = 7;
+
+const HOUR_MS = 3600000;
+
+/** Signed moon−sun elongation in ecliptic longitude, folded to (−180, 180]. */
+export function signedElongation(date) {
+  const moon = modernMoonPosition(date).longitude;
+  const sun = modernSunLongitude(date);
+  return ((moon - sun + 540) % 360) - 180;
+}
+
+/**
+ * The conjunction nearest `date` — the −→+ zero crossing of the signed
+ * elongation — or null if none falls within ±4 days. Hourly scan, then
+ * bisection to well under a minute (the underlying series is only good
+ * to ~5-10 minutes, so the answer's precision outruns its accuracy).
+ */
+export function conjunctionNear(date) {
+  const t0 = date.getTime() - 4 * 24 * HOUR_MS;
+  let prev = signedElongation(new Date(t0));
+  for (let h = 1; h <= 8 * 24; h++) {
+    const t = t0 + h * HOUR_MS;
+    const cur = signedElongation(new Date(t));
+    if (prev < 0 && cur >= 0 && cur < 90) {
+      let lo = t - HOUR_MS;
+      let hi = t;
+      for (let i = 0; i < 30; i++) {
+        const mid = (lo + hi) / 2;
+        if (signedElongation(new Date(mid)) < 0) lo = mid;
+        else hi = mid;
+      }
+      return new Date((lo + hi) / 2);
+    }
+    prev = cur;
+  }
+  return null;
+}
+
+/**
+ * The first instant at or after `from` when the elongation reaches
+ * `deg`. Meant for small targets (the 7° limit) shortly after a
+ * conjunction, where the elongation climbs monotonically at ~0.5°/hour.
+ */
+export function elongationReaches(from, deg) {
+  let t = from.getTime();
+  let guard = 0;
+  while (signedElongation(new Date(t)) < deg && guard++ < 96) t += HOUR_MS;
+  let lo = t - HOUR_MS;
+  let hi = t;
+  for (let i = 0; i < 30; i++) {
+    const mid = (lo + hi) / 2;
+    if (signedElongation(new Date(mid)) < deg) lo = mid;
+    else hi = mid;
+  }
+  return new Date((lo + hi) / 2);
+}
+
+/**
+ * When the moon sets on the evening of `eveDate`, in UTC hours — or
+ * null if it doesn't between 2h before and 8h after sunset. Crossing of
+ * geocentric altitude +0.125°, the standard moonset figure (mean
+ * horizontal parallax less refraction and semidiameter, Meeus ch. 15);
+ * 5-minute scan, bisected to under a minute. Worth ± a few minutes: the
+ * parallax term is a mean, and the horizon is assumed clear and flat.
+ */
+export function moonsetUtcHours(eveDate, observer) {
+  const sunset = sunsetUtcHours(eveDate, observer);
+  if (sunset == null) return null;
+  const midnightUtc = Date.UTC(eveDate.getFullYear(), eveDate.getMonth(), eveDate.getDate(), 0, 0, 0);
+  const altAt = (utcHours) => {
+    const pos = modernMoonPosition(new Date(midnightUtc + utcHours * HOUR_MS));
+    return skyPosition(pos.longitude, pos.latitude, jdAt(eveDate, utcHours), observer).altitude - 0.125;
+  };
+  const STEP = 5 / 60;
+  let prev = altAt(sunset - 2);
+  for (let u = sunset - 2 + STEP; u <= sunset + 8 + 1e-9; u += STEP) {
+    const cur = altAt(u);
+    if (prev > 0 && cur <= 0) {
+      let lo = u - STEP;
+      let hi = u;
+      for (let i = 0; i < 20; i++) {
+        const mid = (lo + hi) / 2;
+        if (altAt(mid) > 0) lo = mid;
+        else hi = mid;
+      }
+      return (lo + hi) / 2;
+    }
+    prev = cur;
+  }
+  return null;
+}
+
+/**
+ * The whole modern question for one evening, answered at once.
+ *
+ * Verdict keys, in the order the evening's facts eliminate them:
+ *   'not-crescent-night' — the moon is nowhere near a first crescent
+ *   'no-crescent-yet'    — conjunction is after sunset this evening
+ *   'daylight-only'      — 7° reached, but the moon sets BEFORE the sun
+ *   'impossible'         — the moon sets before reaching 7°
+ *   'likely'             — 7° passed before sunset, moon still up after
+ *   'challenging'        — 7° reached between sunset and moonset
+ *   'indeterminate'      — no moonset found to test against
+ */
+export function assessEvening(eveDate, observer) {
+  const sunsetUtc = sunsetUtcHours(eveDate, observer);
+  if (sunsetUtc == null) return null;
+  const midnightUtc = Date.UTC(eveDate.getFullYear(), eveDate.getMonth(), eveDate.getDate(), 0, 0, 0);
+  const sunsetInstant = new Date(midnightUtc + sunsetUtc * HOUR_MS);
+  const elongationAtSunset = signedElongation(sunsetInstant);
+  const moonsetUtc = moonsetUtcHours(eveDate, observer);
+  const conjunction = conjunctionNear(sunsetInstant);
+  const sevenDeg = conjunction ? elongationReaches(conjunction, DANJON_LIMIT_DEG) : null;
+
+  let verdict;
+  if (elongationAtSunset > 40 || elongationAtSunset < -25) {
+    verdict = 'not-crescent-night';
+  } else if (elongationAtSunset < 0) {
+    verdict = 'no-crescent-yet';
+  } else if (moonsetUtc == null) {
+    verdict = 'indeterminate';
+  } else {
+    const atMoonset = signedElongation(new Date(midnightUtc + moonsetUtc * HOUR_MS));
+    if (atMoonset < DANJON_LIMIT_DEG) verdict = 'impossible';
+    else if (moonsetUtc <= sunsetUtc) verdict = 'daylight-only';
+    else if (elongationAtSunset >= DANJON_LIMIT_DEG) verdict = 'likely';
+    else verdict = 'challenging';
+  }
+
+  return {
+    sunsetUtc,
+    moonsetUtc,
+    windowMinutes: moonsetUtc != null ? Math.round((moonsetUtc - sunsetUtc) * 60) : null,
+    conjunction,
+    sevenDeg,
+    elongationAtSunset,
+    verdict,
+  };
+}

--- a/src/lib/moonVisibility.js
+++ b/src/lib/moonVisibility.js
@@ -18,10 +18,14 @@
  * moon, so times found by inverting it carry ~5-10 minutes), and
  * skyView's frame conversion for the moonset search.
  *
- * The criterion is deliberately elongation-only. A full modern sighting
- * forecast (Yallop, Odeh) also weighs crescent width and the moon's
- * altitude above the sun; "likely" here is the generous end of modern
- * practice, and the surfaces say so.
+ * Two criteria, coarse then full. The elongation gate (Danjon limit)
+ * answers whether a crescent EXISTS to look for; Yallop's q-test —
+ * the arc of vision against the crescent's width at "best time",
+ * fitted to 295 recorded sightings (Yallop 1997, NAO TN 69) — answers
+ * whether an eye would actually catch it, in bands A (easy) through F
+ * (below the Danjon limit). Geocentric altitudes without refraction,
+ * as Yallop's formulation takes them; the atmosphere itself (cloud,
+ * dust, haze) is outside every criterion here.
  *
  * Cross-checked in moonVisibility.test.js against an independently
  * generated table (Meeus ch. 49 conjunctions verified against
@@ -125,6 +129,88 @@ export function moonsetUtcHours(eveDate, observer) {
 }
 
 /**
+ * The moon's distance in km — Meeus ch. 47's ΣR, truncated to terms of
+ * 10 km and larger (good to ~±30 km, which moves the crescent width by
+ * far less than the q-test can resolve). The mean elements mirror
+ * modernMoonPosition's; only the cosine series differs.
+ */
+export function moonDistanceKm(date) {
+  const T = ((date.getTime() / 86400000 + 2440587.5) - 2451545.0) / 36525;
+  const norm = (d) => ((d % 360) + 360) % 360;
+  const D = norm(297.8501921 + 445267.1114034 * T - 0.0018819 * T * T);
+  const M = norm(357.5291092 + 35999.0502909 * T - 0.0001536 * T * T);
+  const Mp = norm(134.9633964 + 477198.8675055 * T + 0.0087414 * T * T);
+  const F = norm(93.272095 + 483202.0175233 * T - 0.0036539 * T * T);
+  const DEG = Math.PI / 180;
+  const E = 1 - 0.002516 * T;
+  // [coeff (m), d, m, mp, f] — distance terms ≥ 10 km, Meeus table 47.A.
+  const R = [
+    [-20905355, 0, 0, 1, 0], [-3699111, 2, 0, -1, 0], [-2955968, 2, 0, 0, 0],
+    [-569925, 0, 0, 2, 0], [48888, 0, 1, 0, 0], [-3149, 0, 0, 0, 2],
+    [246158, 2, 0, -2, 0], [-152138, 2, -1, -1, 0], [-170733, 2, 0, 1, 0],
+    [-204586, 2, -1, 0, 0], [-129620, 0, 1, -1, 0], [108743, 1, 0, 0, 0],
+    [104755, 0, 1, 1, 0], [10321, 2, 0, 0, -2], [79661, 0, 0, 1, -2],
+    [-34782, 4, 0, -1, 0], [-23210, 0, 0, 3, 0], [-21636, 4, 0, -2, 0],
+    [24208, 2, 1, -1, 0], [30824, 2, 1, 0, 0], [-16675, 1, 1, 0, 0],
+    [-12831, 2, -1, 1, 0], [-10445, 2, 0, 2, 0], [-11650, 4, 0, 0, 0],
+    [14403, 2, 0, -3, 0],
+  ];
+  const sum = R.reduce((acc, [c, d, m, mp, f]) => {
+    const e = m === 0 ? 1 : Math.abs(m) === 1 ? E : E * E;
+    return acc + c * e * Math.cos((d * D + m * M + mp * Mp + f * F) * DEG);
+  }, 0);
+  return 385000.56 + sum / 1000;
+}
+
+/**
+ * Yallop's q-test for one evening (NAO Technical Note 69, 1997) — the
+ * full modern criterion, fitted to 295 recorded first sightings.
+ *
+ * At "best time" (sunset + 4/9 of the sunset-to-moonset lag): ARCV is
+ * the arc of vision, the moon's altitude above the sun's; ARCL the arc
+ * of light, the true angular separation; W' the crescent's width in
+ * arcminutes, the lune's thickness SD·(1 − cos ARCL). Then
+ *
+ *   q = (ARCV − (11.8371 − 6.3226·W' + 0.7319·W'² − 0.1018·W'³)) / 10
+ *
+ * read against Yallop's bands:
+ *   A  q > +0.216   easily visible to the naked eye
+ *   B  q > −0.014   visible in perfect conditions
+ *   C  q > −0.160   may need optical aid to FIND, then naked-eye
+ *   D  q > −0.232   needs optical aid throughout
+ *   E  q > −0.293   not visible even with a telescope
+ *   F  below        not visible; under the Danjon limit
+ *
+ * Returns null when the moon is down by sunset (no lag to take 4/9 of):
+ * the q-test is a dusk criterion and has nothing to say about a
+ * daylight-only window.
+ */
+export function yallopFor(eveDate, observer) {
+  const sunsetUtc = sunsetUtcHours(eveDate, observer);
+  const moonsetUtc = moonsetUtcHours(eveDate, observer);
+  if (sunsetUtc == null || moonsetUtc == null) return null;
+  const lagHours = moonsetUtc - sunsetUtc;
+  if (lagHours <= 0) return null;
+  const bestUtc = sunsetUtc + (4 / 9) * lagHours;
+  const midnightUtc = Date.UTC(eveDate.getFullYear(), eveDate.getMonth(), eveDate.getDate(), 0, 0, 0);
+  const instant = new Date(midnightUtc + bestUtc * HOUR_MS);
+  const jd = jdAt(eveDate, bestUtc);
+  const moon = modernMoonPosition(instant);
+  const sunLon = modernSunLongitude(instant);
+  const moonH = skyPosition(moon.longitude, moon.latitude, jd, observer);
+  const sunH = skyPosition(sunLon, 0, jd, observer);
+  const DEG = Math.PI / 180;
+  const dLon = ((moon.longitude - sunLon + 540) % 360) - 180;
+  const arcl = Math.acos(Math.cos(moon.latitude * DEG) * Math.cos(dLon * DEG)) / DEG;
+  const arcv = moonH.altitude - sunH.altitude;
+  const sdArcmin = (1737.4 / moonDistanceKm(instant)) * (180 / Math.PI) * 60;
+  const wPrime = sdArcmin * (1 - Math.cos(arcl * DEG));
+  const q = (arcv - (11.8371 - 6.3226 * wPrime + 0.7319 * wPrime ** 2 - 0.1018 * wPrime ** 3)) / 10;
+  const code = q > 0.216 ? 'A' : q > -0.014 ? 'B' : q > -0.16 ? 'C' : q > -0.232 ? 'D' : q > -0.293 ? 'E' : 'F';
+  return { bestUtc, lagMinutes: Math.round(lagHours * 60), arcv, arcl, wPrime, q, code };
+}
+
+/**
  * The whole modern question for one evening, answered at once.
  *
  * Verdict keys, in the order the evening's facts eliminate them:
@@ -169,5 +255,9 @@ export function assessEvening(eveDate, observer) {
     sevenDeg,
     elongationAtSunset,
     verdict,
+    // The full criterion, where it applies: a crescent-shaped evening
+    // with the moon still up at sunset.
+    yallop:
+      elongationAtSunset >= 0 && elongationAtSunset <= 40 ? yallopFor(eveDate, observer) : null,
   };
 }

--- a/src/lib/moonVisibility.test.js
+++ b/src/lib/moonVisibility.test.js
@@ -152,3 +152,34 @@ describe("Yallop's q-test", () => {
     expect(y.q).toBeGreaterThan(-0.16);
   });
 });
+
+describe('one city stands for the Land (the claim on the /sky panel)', () => {
+  // The panel says Jerusalem represents Israel the way KH 11:17's single
+  // reference does, moving the q-test by at most about one band across
+  // the country's full span. Held here across the extremes.
+  const SPAN = [
+    { latitude: 33.28, longitude: 35.57 }, // Metula, the north tip
+    { latitude: 31.78, longitude: 35.2137 }, // Jerusalem
+    { latitude: 32.08, longitude: 34.78 }, // the coast
+    { latitude: 29.55, longitude: 34.95 }, // Eilat, the south tip
+  ];
+  const BANDS = 'ABCDEF';
+
+  it('on a clear evening every city agrees', () => {
+    const codes = SPAN.map((o) => yallopFor(new Date(2026, 7, 14), o).code);
+    expect(new Set(codes).size).toBe(1);
+    expect(codes[0]).toBe('A');
+  });
+
+  it('on knife-edge evenings the spread is one band, south favoured', () => {
+    for (const [y, m, d] of [[2026, 7, 13], [2026, 10, 10], [1178, 3, 27]]) {
+      const qs = SPAN.map((o) => yallopFor(new Date(y, m, d), o));
+      const idx = qs.map((r) => BANDS.indexOf(r.code));
+      expect(Math.max(...idx) - Math.min(...idx), `${y}-${m + 1}-${d}`).toBeLessThanOrEqual(1);
+      // Eilat (last) never worse than Metula (first): the south's crescent
+      // stands a little higher — the geometry behind KH 18:4's "weigh
+      // where the witnesses stood".
+      expect(qs[3].q, `${y}-${m + 1}-${d}`).toBeGreaterThan(qs[0].q);
+    }
+  });
+});

--- a/src/lib/moonVisibility.test.js
+++ b/src/lib/moonVisibility.test.js
@@ -154,14 +154,16 @@ describe("Yallop's q-test", () => {
 });
 
 describe('one city stands for the Land (the claim on the /sky panel)', () => {
-  // The panel says Jerusalem represents Israel the way KH 11:17's single
-  // reference does, moving the q-test by at most about one band across
-  // the country's full span. Held here across the extremes.
+  // The panel says Jerusalem represents the Land the way KH 11:17's
+  // single reference does, moving the q-test by at most one band across
+  // the classical span — from Dan to Beersheba, since the modern map's
+  // southern point (Eilat) sits outside the halachic Land by most
+  // reckonings. Held here across that span.
   const SPAN = [
-    { latitude: 33.28, longitude: 35.57 }, // Metula, the north tip
+    { latitude: 33.249, longitude: 35.652 }, // Dan, the northern byword
     { latitude: 31.78, longitude: 35.2137 }, // Jerusalem
     { latitude: 32.08, longitude: 34.78 }, // the coast
-    { latitude: 29.55, longitude: 34.95 }, // Eilat, the south tip
+    { latitude: 31.25, longitude: 34.79 }, // Beersheba, the southern byword
   ];
   const BANDS = 'ABCDEF';
 
@@ -176,9 +178,9 @@ describe('one city stands for the Land (the claim on the /sky panel)', () => {
       const qs = SPAN.map((o) => yallopFor(new Date(y, m, d), o));
       const idx = qs.map((r) => BANDS.indexOf(r.code));
       expect(Math.max(...idx) - Math.min(...idx), `${y}-${m + 1}-${d}`).toBeLessThanOrEqual(1);
-      // Eilat (last) never worse than Metula (first): the south's crescent
-      // stands a little higher — the geometry behind KH 18:4's "weigh
-      // where the witnesses stood".
+      // Beersheba (last) never worse than Dan (first): the south's
+      // crescent stands a little higher — the geometry behind KH 18:4's
+      // "weigh where the witnesses stood".
       expect(qs[3].q, `${y}-${m + 1}-${d}`).toBeGreaterThan(qs[0].q);
     }
   });

--- a/src/lib/moonVisibility.test.js
+++ b/src/lib/moonVisibility.test.js
@@ -1,0 +1,99 @@
+/**
+ * The modern first-crescent check, pinned against an independent table.
+ *
+ * The reference times come from a separate Meeus implementation (ch. 49
+ * conjunction series, full to its last term; ch. 25/47 longitudes with
+ * a binary search for 7°) whose conjunctions were verified against
+ * timeanddate.com. This module inverts a moon series truncated at
+ * 0.05°, and the moon closes on the sun at ~0.51°/hour, so times may
+ * differ by ~6 minutes — the tolerances say 15 to stay clear of flakes,
+ * not because the agreement is that loose.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  signedElongation,
+  conjunctionNear,
+  elongationReaches,
+  moonsetUtcHours,
+  assessEvening,
+  DANJON_LIMIT_DEG,
+} from './moonVisibility';
+import { sunsetUtcHours } from './localObserver';
+
+const JERUSALEM = { latitude: 31.78, longitude: 35.2137 };
+const minutesApart = (a, b) => Math.abs(a.getTime() - b.getTime()) / 60000;
+
+describe('conjunction and the 7° instant, against the independent table', () => {
+  // Aug 2026: conjunction 2026-08-12 20:36 IDT = 17:36 UTC; 7° at 09:10 IDT next day.
+  it('finds the Av/Elul 2026 conjunction', () => {
+    const conj = conjunctionNear(new Date(Date.UTC(2026, 7, 13)));
+    expect(minutesApart(conj, new Date(Date.UTC(2026, 7, 12, 17, 36)))).toBeLessThan(15);
+  });
+
+  it('finds when that moon opens 7°', () => {
+    const conj = conjunctionNear(new Date(Date.UTC(2026, 7, 13)));
+    const seven = elongationReaches(conj, DANJON_LIMIT_DEG);
+    expect(minutesApart(seven, new Date(Date.UTC(2026, 7, 13, 6, 10)))).toBeLessThan(15);
+    // And the elongation there really is 7, by its own reckoning.
+    expect(signedElongation(seven)).toBeCloseTo(7, 3);
+  });
+
+  // Nov 2026: conjunction 2026-11-09 09:02 IST = 07:02 UTC; 7° at 23:52 IST = 21:52 UTC.
+  it('finds a winter conjunction and its 7° instant', () => {
+    const conj = conjunctionNear(new Date(Date.UTC(2026, 10, 9)));
+    expect(minutesApart(conj, new Date(Date.UTC(2026, 10, 9, 7, 2)))).toBeLessThan(15);
+    const seven = elongationReaches(conj, DANJON_LIMIT_DEG);
+    expect(minutesApart(seven, new Date(Date.UTC(2026, 10, 9, 21, 52)))).toBeLessThan(15);
+  });
+
+  it('returns null when no conjunction is near', () => {
+    // Full moon of Aug 2026 is around the 28th; ±4 days finds nothing.
+    expect(conjunctionNear(new Date(Date.UTC(2026, 7, 27)))).toBeNull();
+  });
+});
+
+describe('moonset', () => {
+  it('on a first-crescent evening the moon sets after the sun, within hours', () => {
+    // Evening of 2026-08-13, the first evening past 7°.
+    const eve = new Date(2026, 7, 13);
+    const sunset = sunsetUtcHours(eve, JERUSALEM);
+    const moonset = moonsetUtcHours(eve, JERUSALEM);
+    expect(moonset).toBeGreaterThan(sunset);
+    expect(moonset - sunset).toBeLessThan(3);
+  });
+});
+
+describe('the whole evening, assessed', () => {
+  it('the evening OF the Aug 2026 conjunction: no crescent yet', () => {
+    // Conjunction 17:36 UTC; Jerusalem sunset that day is ~16:35 UTC.
+    const a = assessEvening(new Date(2026, 7, 12), JERUSALEM);
+    expect(a.elongationAtSunset).toBeLessThan(0);
+    expect(a.verdict).toBe('no-crescent-yet');
+  });
+
+  it('the next evening: a sightable crescent, and the numbers cohere', () => {
+    const a = assessEvening(new Date(2026, 7, 13), JERUSALEM);
+    // ~23h past conjunction at ~0.51°/h: elongation ~11-12° at sunset.
+    expect(a.elongationAtSunset).toBeGreaterThan(DANJON_LIMIT_DEG);
+    expect(a.elongationAtSunset).toBeLessThan(20);
+    expect(a.verdict).toBe('likely');
+    expect(a.windowMinutes).toBeGreaterThan(0);
+    expect(a.conjunction).not.toBeNull();
+    expect(a.sevenDeg.getTime()).toBeGreaterThan(a.conjunction.getTime());
+  });
+
+  it('a full-moon evening is not a crescent night', () => {
+    const a = assessEvening(new Date(2026, 7, 27), JERUSALEM);
+    expect(a.verdict).toBe('not-crescent-night');
+  });
+
+  it("holds up on the Rambam's own worked evening, eight centuries back", () => {
+    // The night beginning 2 Iyar 4938 — 1178-04-27 civil evening — which
+    // KH 17 judges visible. The modern check should at least call it a
+    // real crescent evening with a window, not contradict him outright.
+    const a = assessEvening(new Date(1178, 3, 27), JERUSALEM);
+    expect(['likely', 'challenging']).toContain(a.verdict);
+    expect(a.elongationAtSunset).toBeGreaterThan(0);
+    expect(a.windowMinutes).toBeGreaterThan(15);
+  });
+});

--- a/src/lib/moonVisibility.test.js
+++ b/src/lib/moonVisibility.test.js
@@ -16,6 +16,8 @@ import {
   elongationReaches,
   moonsetUtcHours,
   assessEvening,
+  moonDistanceKm,
+  yallopFor,
   DANJON_LIMIT_DEG,
 } from './moonVisibility';
 import { sunsetUtcHours } from './localObserver';
@@ -95,5 +97,58 @@ describe('the whole evening, assessed', () => {
     expect(['likely', 'challenging']).toContain(a.verdict);
     expect(a.elongationAtSunset).toBeGreaterThan(0);
     expect(a.windowMinutes).toBeGreaterThan(15);
+  });
+});
+
+describe("the moon's distance (for the crescent's width)", () => {
+  it('swings between a plausible perigee and apogee over two months', () => {
+    let min = Infinity;
+    let max = 0;
+    for (let h = 0; h < 60 * 24; h += 6) {
+      const d = moonDistanceKm(new Date(Date.UTC(2026, 0, 1) + h * 3600000));
+      min = Math.min(min, d);
+      max = Math.max(max, d);
+    }
+    expect(min).toBeGreaterThan(355000);
+    expect(min).toBeLessThan(372000);
+    expect(max).toBeGreaterThan(400000);
+    expect(max).toBeLessThan(407500);
+  });
+});
+
+describe("Yallop's q-test", () => {
+  const JLM = { latitude: 31.78, longitude: 35.2137 };
+
+  it('has nothing to say on the conjunction evening: the moon is down by dusk', () => {
+    expect(yallopFor(new Date(2026, 7, 12), JLM)).toBeNull();
+  });
+
+  it('the first evening past 7° is band D — the gate passes, the eye fails', () => {
+    // THE case that shows why the full check exists: elongation ~11° at
+    // sunset clears the Danjon gate ("likely" by the coarse reading),
+    // but ARCV ~7.5° against a 0.4' crescent gives q ~ -0.20 — optical
+    // aid needed. First naked-eye sighting of this moon is the NEXT
+    // evening, which is what the record shows for crescents this young.
+    const y = yallopFor(new Date(2026, 7, 13), JLM);
+    expect(y.code).toBe('D');
+    expect(y.q).toBeGreaterThan(-0.25);
+    expect(y.q).toBeLessThan(-0.15);
+    expect(assessEvening(new Date(2026, 7, 13), JLM).yallop.code).toBe('D');
+  });
+
+  it('one evening later the same moon is band A — easily visible', () => {
+    const y = yallopFor(new Date(2026, 7, 14), JLM);
+    expect(y.code).toBe('A');
+    expect(y.q).toBeGreaterThan(0.216);
+  });
+
+  it("the Rambam's worked evening of 1178 comes out visible, as KH 17 says", () => {
+    // q = -0.006: band B, visible in perfect conditions — his verdict
+    // and the modern criterion agree across eight centuries. (Pinned to
+    // B-or-C: the value sits a hair from the band edge, and the moon
+    // series is only good to ~0.05 deg.)
+    const y = yallopFor(new Date(1178, 3, 27), JLM);
+    expect(['B', 'C']).toContain(y.code);
+    expect(y.q).toBeGreaterThan(-0.16);
   });
 });


### PR DESCRIPTION
Absolutely — here’s a cleaner, more readable version with the substance unchanged:

---

## Batch since integration of #47

**20 commits · zero conflicts against current `main` · 892 tests green**

### `/sky`: modern first-crescent check

`/sky` now includes a modern first-crescent check (`src/lib/moonVisibility.js`). This is **comparison-only**; nothing from it feeds the verdict path.

* Computes **true conjunction** and the **7-degree Danjon-limit instant** by inverting the Meeus series already in `modernAstronomy.js`.
* Computes **real Jerusalem moonset** via altitude search.
* Implements **Yallop’s q-test** (NAO TN 69), including the truncated ch. 47 distance series it requires.
* Shows the modern result beside the **KH 17 verdict**, with agreement or disagreement stated in words.
* Pinned against:

  * an independently generated Meeus table;
  * the Rambam’s **1178 worked evening**, where his “visible” result lands in **Yallop band B** — eight centuries apart.
* A reader raised the question of whether Jerusalem-only data is apples-to-oranges against the Rambam’s Land-wide frame. Measured across the classical span from **Dan to Beersheba**, the q-test moves by at most one band, and only on knife-edge evenings; the south is slightly favoured. This is stated on the panel and pinned in tests.
* Sky bodies are now labelled:

  * **Sun (Rambam)**
  * **Sun (actual)**
* The toggle is now **“Show the actual sky.”**

### Cards now compute real nights

The cards no longer ask the reader to provide assertions.

* **“Tonight, where you are”** opens on the next sighting night, using the same `eveningOf` derivation as `/sky`.
* The **KH 17:3–4 early-exit card** is now a calculator:

  * presets feed the engine;
  * sliders remain available for exploration;
  * the “computed by the engine” claim disappears as soon as a slider is touched.
* **MoladLadder** now shows the full **KH 6:12–14** climb:

  * cycles;
  * common/leap remainders;
  * running totals.

  Its result is held equal to `moladTishrei` across eras.

### Chapters 17 and 19: content and geometry

* Ch. 19’s declination card now includes a **two-great-circle sphere**, rendered as pure SVG orthographic projection via the new `sphereProjection.js`. `three.js` stays out of the book bundle.
* Ch. 17 briefly gained three geometry figures — and then lost them, at the same reader’s insistence. They confused more than they taught, and **KH 17:24** explicitly says the *whys* were left to the geometry books.
* What survived is tested prose, including a fact found along the way:

  * `sqrt(lon² + lat²)` for the two **KH 17:5 / 17:8** tables stays within **56′–61′ in every sign** — the moon’s own parallax showing through.
* Hebrew terms are now introduced at first mention, from **אורך ראשון** through **קשת הראייה**.
* Chain step numbers were added to section headings.
* Single “stakes” sentences were added to:

  * **Ch. 13** — where the two degrees land;
  * **Ch. 16** — why there is no monthly eclipse;
  * **Ch. 17** — quantifying the two-thirds lever.

### New essay: `/book/numbers`

A new standalone essay: **“Thirteen numbers.”**

It:

* opens at the window — *will a crescent show tonight?* — and follows what that innocent question demands;
* explains the calendar’s **three numbers**;
* explains astronomy’s **five position/speed pairs**;
* shows why the **apogee** and the **node** earn their places;
* funnels everything down to the **one number the verdict reads**.

Every figure on the page renders directly from the engine’s constants and is pinned in tests, so the essay and the calculators cannot disagree.

### #47

This batch supersedes what remained visible on **#47**, so feel free to close that one.

As before, every commit message carries its full reasoning. Happy to split or drop anything that doesn’t fit upstream.
